### PR TITLE
Add sloped skyline and windows

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -11,9 +11,14 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 )
 
+type window struct {
+	x, y, w, h float64
+}
+
 type building struct {
 	x, w, h float64
 	color   color.Color
+	windows []window
 }
 
 type Game struct {
@@ -27,12 +32,20 @@ func newGame() *Game {
 	bw := float64(g.Width) / gorillas.BuildingCount
 	for i := 0; i < gorillas.BuildingCount; i++ {
 		h := g.Buildings[i].H
-		g.buildings = append(g.buildings, building{
+		b := building{
 			x:     float64(i) * bw,
 			w:     bw,
 			h:     h,
 			color: color.RGBA{uint8(rand.Intn(200)), uint8(rand.Intn(200)), uint8(rand.Intn(200)), 255},
-		})
+		}
+		for wx := b.x + 3; wx < b.x+b.w-3; wx += 6 {
+			for wy := float64(g.Height) - 3; wy > float64(g.Height)-b.h+3; wy -= 6 {
+				if rand.Intn(3) != 0 {
+					b.windows = append(b.windows, window{wx, wy, 3, 3})
+				}
+			}
+		}
+		g.buildings = append(g.buildings, b)
 	}
 	return g
 }
@@ -82,6 +95,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	screen.Fill(color.RGBA{0, 0, 0, 255})
 	for i, b := range g.buildings {
 		ebitenutil.DrawRect(screen, b.x, float64(g.Height)-b.h, b.w-1, b.h, b.color)
+		for _, w := range b.windows {
+			ebitenutil.DrawRect(screen, w.x, w.y, w.w, w.h, color.RGBA{255, 255, 0, 255})
+		}
 		_ = i
 	}
 	for _, gr := range g.Gorillas {

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -11,17 +11,14 @@ import (
 )
 
 type building struct {
-	h int
+	h       int
+	windows []int
 }
 
 type Game struct {
 	*gorillas.Game
-	screen             tcell.Screen
-	buildings          []building
-	gorillas           [2]int
-	bananaX, bananaY   float64
-	bananaVX, bananaVY float64
-	bananaActive       bool
+	screen    tcell.Screen
+	buildings []building
 }
 
 const buildingWidth = 8
@@ -29,28 +26,36 @@ const buildingWidth = 8
 func newGame() *Game {
 	g := &Game{Game: gorillas.NewGame(80, 24)}
 	rand.Seed(time.Now().UnixNano())
-	for i := 0; i < g.Width; i += buildingWidth {
-		g.buildings = append(g.buildings, building{rand.Intn(g.Height - 5)})
+	for _, b := range g.Buildings {
+		var wins []int
+		top := g.Height - int(b.H) + 2
+		for y := g.Height - 2; y > top; y -= 2 {
+			if rand.Intn(3) != 0 {
+				wins = append(wins, y)
+			}
+		}
+		g.buildings = append(g.buildings, building{h: int(b.H), windows: wins})
 	}
-	g.gorillas[0] = 1
-	g.gorillas[1] = len(g.buildings) - 2
 	return g
 }
 
 func (g *Game) draw() {
 	g.screen.Clear()
 	for i, b := range g.buildings {
+		x := i*buildingWidth + 4
 		for y := g.Height - 1; y >= g.Height-b.h; y-- {
-			g.screen.SetContent(i*buildingWidth+4, y, '#', nil, tcell.StyleDefault)
+			g.screen.SetContent(x, y, '#', nil, tcell.StyleDefault)
 		}
-		_ = i
+		for _, wy := range b.windows {
+			g.screen.SetContent(x, wy, 'o', nil, tcell.StyleDefault)
+		}
 	}
-	g.drawGorilla(g.gorillas[0])
-	g.drawGorilla(g.gorillas[1])
+	g.drawGorilla(0)
+	g.drawGorilla(1)
 	// draw a simple sun
 	g.screen.SetContent(g.Width-2, 1, 'O', nil, tcell.StyleDefault)
-	if g.bananaActive {
-		g.screen.SetContent(int(g.bananaX), int(g.bananaY), 'o', nil, tcell.StyleDefault)
+	if g.Banana.Active {
+		g.screen.SetContent(int(g.Banana.X), int(g.Banana.Y), 'o', nil, tcell.StyleDefault)
 	}
 	s := fmt.Sprintf("A:%2.0f P:%2.0f P%d %d-%d", g.Angle, g.Power, g.Current+1, g.Wins[0], g.Wins[1])
 	for i, r := range s {
@@ -60,8 +65,8 @@ func (g *Game) draw() {
 }
 
 func (g *Game) drawGorilla(idx int) {
-	x := idx*buildingWidth + 4
-	y := g.Height - g.buildings[idx].h - 1
+	x := int(g.Gorillas[idx].X)
+	y := int(g.Gorillas[idx].Y) - 1
 	style := tcell.StyleDefault
 	g.screen.SetContent(x, y-2, 'O', nil, style)
 	g.screen.SetContent(x-1, y-1, '/', nil, style)
@@ -72,19 +77,7 @@ func (g *Game) drawGorilla(idx int) {
 }
 
 func (g *Game) throw() {
-	startX := float64(g.gorillas[g.Current]*8 + 4)
-	startY := float64(g.Height - g.buildings[g.gorillas[g.Current]].h - 1)
-	radians := g.Angle * math.Pi / 180
-	speed := g.Power / 2
-	vx := math.Cos(radians) * speed
-	if g.Current == 1 {
-		vx = -vx
-	}
-	g.bananaX = startX
-	g.bananaY = startY
-	g.bananaVX = vx / 5
-	g.bananaVY = -math.Sin(radians) * speed / 5
-	g.bananaActive = true
+	g.Throw()
 }
 
 func (g *Game) run() error {
@@ -103,30 +96,8 @@ func (g *Game) run() error {
 		g.draw()
 		select {
 		case <-ticker.C:
-			if g.bananaActive {
-				g.bananaX += g.bananaVX
-				g.bananaY += g.bananaVY
-				g.bananaVY += 0.2
-				idx := int(g.bananaX) / buildingWidth
-				if idx >= 0 && idx < len(g.buildings) {
-					if int(g.bananaY) >= g.Height-g.buildings[idx].h {
-						g.bananaActive = false
-						g.Current = (g.Current + 1) % 2
-					}
-					for _, gidx := range g.gorillas {
-						if idx == gidx && int(g.bananaY) >= g.Height-g.buildings[gidx].h-2 {
-							g.bananaActive = false
-							g.Wins[g.Current]++
-							next := g.Current
-							g.Reset()
-							g.Current = next
-						}
-					}
-				}
-				if int(g.bananaY) >= g.Height || int(g.bananaX) < 0 || int(g.bananaX) >= g.Width {
-					g.bananaActive = false
-					g.Current = (g.Current + 1) % 2
-				}
+			if g.Banana.Active {
+				g.Step()
 			}
 		default:
 			ev := s.PollEvent()

--- a/game.go
+++ b/game.go
@@ -37,10 +37,46 @@ func NewGame(width, height int) *Game {
 	g := &Game{Width: width, Height: height, Angle: 45, Power: 50}
 	rand.Seed(time.Now().UnixNano())
 	bw := float64(width) / BuildingCount
+
+	// create a sloping skyline similar to the original BASIC version
+	slope := rand.Intn(6) + 1
+	newHt := float64(height) * 0.3
+	if slope == 2 || slope == 6 {
+		newHt = float64(height) * 0.7
+	}
+	htInc := float64(height) / 20
+
 	for i := 0; i < BuildingCount; i++ {
-		h := float64(100 + rand.Intn(height-200))
+		x := float64(i) * bw
+		switch slope {
+		case 1:
+			newHt += htInc
+		case 2:
+			newHt -= htInc
+		case 3, 5:
+			if x > float64(width)/2 {
+				newHt -= 2 * htInc
+			} else {
+				newHt += 2 * htInc
+			}
+		case 4:
+			if x > float64(width)/2 {
+				newHt += 2 * htInc
+			} else {
+				newHt -= 2 * htInc
+			}
+		}
+
+		h := newHt + rand.Float64()*float64(height)/8
+		if h < float64(height)*0.1 {
+			h = float64(height) * 0.1
+		}
+		if h > float64(height)*0.9 {
+			h = float64(height) * 0.9
+		}
+
 		g.Buildings = append(g.Buildings, Building{
-			X: float64(i) * bw,
+			X: x,
 			W: bw,
 			H: h,
 		})


### PR DESCRIPTION
## Summary
- create sloped cityscape generation similar to `MakeCityScape`
- show windows on Ebiten buildings
- show windows on tcell buildings
- use `Game.Step` in tcell frontend

## Testing
- `go build ./...` *(fails: access to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c89ebb3b0832f8aaeea960cda771d