### PR TITLE
Improve sound support

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"image/color"
 	"math/rand"
@@ -36,8 +37,9 @@ type Game struct {
 	buildings []building
 }
 
-func newGame() *Game {
+func newGame(settings gorillas.Settings) *Game {
 	g := &Game{Game: gorillas.NewGame(800, 600)}
+	g.Game.Settings = settings
 	rand.Seed(time.Now().UnixNano())
 	bw := float64(g.Width) / gorillas.BuildingCount
 	for i := 0; i < gorillas.BuildingCount; i++ {
@@ -129,7 +131,10 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 func main() {
 	ebiten.SetWindowSize(800, 600)
 	ebiten.SetWindowTitle("Gorillas Ebiten")
-	game := newGame()
+	settings := gorillas.LoadSettings()
+	flag.BoolVar(&settings.UseSound, "sound", settings.UseSound, "enable sound")
+	flag.Parse()
+	game := newGame(settings)
 	if err := ebiten.RunGame(game); err != nil {
 		panic(err)
 	}

--- a/cmd/gorillia-tcell/intro.go
+++ b/cmd/gorillia-tcell/intro.go
@@ -3,6 +3,7 @@ package main
 import (
 	"time"
 
+	"github.com/arran4/gorillas"
 	"github.com/gdamore/tcell/v2"
 )
 
@@ -36,7 +37,7 @@ func drawGorillaFrame(s tcell.Screen, x, y int, frame []string) {
 	}
 }
 
-func showIntroMovie(s tcell.Screen) {
+func showIntroMovie(s tcell.Screen, useSound bool) {
 	w, h := s.Size()
 	lines := []string{
 		"QBasic GORILLAS",
@@ -48,6 +49,9 @@ func showIntroMovie(s tcell.Screen) {
 		drawString(s, (w-len(line))/2, h/2-1+i, line)
 	}
 	s.Show()
+	if useSound {
+		gorillas.PlayIntroMusic()
+	}
 	time.Sleep(1500 * time.Millisecond)
 	for i := 0; i < 4; i++ {
 		drawGorillaFrame(s, w/2-10, h/2+2, gorillaFrames[i%len(gorillaFrames)])
@@ -58,7 +62,7 @@ func showIntroMovie(s tcell.Screen) {
 	time.Sleep(700 * time.Millisecond)
 }
 
-func introScreen(s tcell.Screen) bool {
+func introScreen(s tcell.Screen, useSound bool) bool {
 	w, h := s.Size()
 	cx := w/2 - 10
 	cy := h/2 - 2
@@ -87,7 +91,7 @@ func introScreen(s tcell.Screen) bool {
 			case 'p', 'P':
 				return true
 			case 'v', 'V':
-				showIntroMovie(s)
+				showIntroMovie(s, useSound)
 			}
 		}
 	}

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"math"
 	"math/rand"
@@ -25,8 +26,9 @@ type Game struct {
 
 const buildingWidth = 8
 
-func newGame() *Game {
+func newGame(settings gorillas.Settings) *Game {
 	g := &Game{Game: gorillas.NewGame(80, 24)}
+	g.Game.Settings = settings
 	rand.Seed(time.Now().UnixNano())
 	for _, b := range g.Buildings {
 		var wins []int
@@ -168,11 +170,15 @@ func main() {
 	}
 	defer s.Fini()
 
-	if !introScreen(s) {
+	settings := gorillas.LoadSettings()
+	flag.BoolVar(&settings.UseSound, "sound", settings.UseSound, "enable sound")
+	flag.Parse()
+
+	if !introScreen(s, settings.UseSound) {
 		return
 	}
 
-	g := newGame()
+	g := newGame(settings)
 	if err := g.run(s); err != nil {
 		panic(err)
 	}

--- a/config.go
+++ b/config.go
@@ -1,0 +1,33 @@
+package gorillas
+
+import (
+	"os"
+	"strconv"
+)
+
+// LoadSettings reads configuration from environment variables.
+// The flag package can override these values using its BoolVar API.
+// Recognised variables:
+//
+//	GORILLAS_SOUND - set to 'true' or 'false' to enable or disable sound.
+//	GORILLAS_OLD_EXPLOSIONS - 'true' to use the old explosion style.
+//	GORILLAS_EXPLOSION_RADIUS - floating point radius for new explosions.
+func LoadSettings() Settings {
+	s := DefaultSettings()
+	if v, ok := os.LookupEnv("GORILLAS_SOUND"); ok {
+		if b, err := strconv.ParseBool(v); err == nil {
+			s.UseSound = b
+		}
+	}
+	if v, ok := os.LookupEnv("GORILLAS_OLD_EXPLOSIONS"); ok {
+		if b, err := strconv.ParseBool(v); err == nil {
+			s.UseOldExplosions = b
+		}
+	}
+	if v, ok := os.LookupEnv("GORILLAS_EXPLOSION_RADIUS"); ok {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			s.NewExplosionRadius = f
+		}
+	}
+	return s
+}

--- a/game.go
+++ b/game.go
@@ -21,6 +21,7 @@ type Banana struct {
 }
 
 type Settings struct {
+	UseSound           bool
 	UseOldExplosions   bool
 	NewExplosionRadius float64
 }
@@ -33,7 +34,7 @@ type Explosion struct {
 }
 
 func DefaultSettings() Settings {
-	return Settings{NewExplosionRadius: 40}
+	return Settings{UseSound: true, NewExplosionRadius: 40}
 }
 
 type Game struct {
@@ -117,6 +118,9 @@ func (g *Game) startGorillaExplosion(idx int) {
 	if base <= 0 {
 		base = 16
 	}
+	if g.Settings.UseSound {
+		PlayBeep()
+	}
 	g.Explosion = Explosion{X: g.Gorillas[idx].X, Y: g.Gorillas[idx].Y}
 	if g.Settings.UseOldExplosions {
 		for i := 1; i <= int(base); i++ {
@@ -132,6 +136,9 @@ func (g *Game) startGorillaExplosion(idx int) {
 }
 
 func (g *Game) Throw() {
+	if g.Settings.UseSound {
+		PlayBeep()
+	}
 	start := g.Gorillas[g.Current]
 	radians := g.Angle * math.Pi / 180
 	speed := g.Power / 2

--- a/sound.go
+++ b/sound.go
@@ -1,0 +1,50 @@
+package gorillas
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/hajimehoshi/ebiten/v2/audio"
+)
+
+const sampleRate = 44100
+
+var (
+	audioOnce  sync.Once
+	audioCtx   *audio.Context
+	beepSample []byte
+)
+
+func initAudio() {
+	audioCtx = audio.NewContext(sampleRate)
+	n := sampleRate / 10
+	beepSample = make([]byte, n*4)
+	for i := 0; i < n; i++ {
+		v := math.Sin(2 * math.Pi * 440 * float64(i) / sampleRate)
+		s := int16(v * 0.3 * 32767)
+		beepSample[i*4] = byte(s)
+		beepSample[i*4+1] = byte(s >> 8)
+		beepSample[i*4+2] = byte(s)
+		beepSample[i*4+3] = byte(s >> 8)
+	}
+}
+
+func PlayBeep() {
+	audioOnce.Do(initAudio)
+	if audioCtx != nil {
+		p := audioCtx.NewPlayer(bytes.NewReader(beepSample))
+		p.Play()
+	} else {
+		fmt.Print("\a")
+	}
+}
+
+func PlayIntroMusic() {
+	for i := 0; i < 3; i++ {
+		PlayBeep()
+		time.Sleep(100 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Summary
- generate a short sine-wave sample and play it using Ebiten's audio context
- continue to beep for intro and game actions when `UseSound` is enabled

## Testing
- `go vet ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c92e7e0cc832fa11a577201375cdf