### PR TITLE
Persist win statistics

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -38,6 +38,7 @@ type Game struct {
 
 func newGame() *Game {
 	g := &Game{Game: gorillas.NewGame(800, 600)}
+	g.LoadScores()
 	rand.Seed(time.Now().UnixNano())
 	bw := float64(g.Width) / gorillas.BuildingCount
 	for i := 0; i < gorillas.BuildingCount; i++ {
@@ -133,4 +134,6 @@ func main() {
 	if err := ebiten.RunGame(game); err != nil {
 		panic(err)
 	}
+	game.SaveScores()
+	fmt.Println(game.StatsString())
 }

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -27,6 +27,7 @@ const buildingWidth = 8
 
 func newGame() *Game {
 	g := &Game{Game: gorillas.NewGame(80, 24)}
+	g.LoadScores()
 	rand.Seed(time.Now().UnixNano())
 	for _, b := range g.Buildings {
 		var wins []int
@@ -176,4 +177,6 @@ func main() {
 	if err := g.run(s); err != nil {
 		panic(err)
 	}
+	g.SaveScores()
+	fmt.Println(g.StatsString())
 }

--- a/game.go
+++ b/game.go
@@ -1,8 +1,11 @@
 package gorillas
 
 import (
+	"encoding/json"
+	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	"time"
 )
 
@@ -36,6 +39,37 @@ func DefaultSettings() Settings {
 	return Settings{NewExplosionRadius: 40}
 }
 
+// LoadScores reads the persistent win totals from disk.
+func (g *Game) LoadScores() {
+	file := g.ScoreFile
+	if file == "" {
+		file = defaultScoreFile
+	}
+	b, err := os.ReadFile(file)
+	if err == nil {
+		_ = json.Unmarshal(b, &g.TotalWins)
+	}
+}
+
+// SaveScores writes the accumulated win totals to disk.
+func (g *Game) SaveScores() {
+	file := g.ScoreFile
+	if file == "" {
+		file = defaultScoreFile
+	}
+	b, err := json.Marshal(g.TotalWins)
+	if err == nil {
+		_ = os.WriteFile(file, b, 0644)
+	}
+}
+
+// StatsString returns a printable summary of wins this session and overall.
+func (g *Game) StatsString() string {
+	session := fmt.Sprintf("Session - P1:%d P2:%d", g.Wins[0], g.Wins[1])
+	total := fmt.Sprintf("Overall - P1:%d P2:%d", g.TotalWins[0], g.TotalWins[1])
+	return session + "\n" + total
+}
+
 type Game struct {
 	Width, Height int
 	Buildings     []Building
@@ -47,12 +81,15 @@ type Game struct {
 	Power         float64
 	Current       int
 	Wins          [2]int
+	TotalWins     [2]int
+	ScoreFile     string
 }
 
 const BuildingCount = 10
+const defaultScoreFile = "gorillas_scores.json"
 
 func NewGame(width, height int) *Game {
-	g := &Game{Width: width, Height: height, Angle: 45, Power: 50}
+	g := &Game{Width: width, Height: height, Angle: 45, Power: 50, ScoreFile: defaultScoreFile}
 	g.Settings = DefaultSettings()
 	rand.Seed(time.Now().UnixNano())
 	bw := float64(width) / BuildingCount
@@ -107,9 +144,13 @@ func NewGame(width, height int) *Game {
 
 func (g *Game) Reset() {
 	wins := g.Wins
+	totals := g.TotalWins
+	file := g.ScoreFile
 	*g = *NewGame(g.Width, g.Height)
 	g.Settings = DefaultSettings()
 	g.Wins = wins
+	g.TotalWins = totals
+	g.ScoreFile = file
 }
 
 func (g *Game) startGorillaExplosion(idx int) {
@@ -176,6 +217,8 @@ func (g *Game) Step() {
 		if math.Abs(gr.X-g.Banana.X) < 5 && math.Abs(gr.Y-g.Banana.Y) < 10 {
 			g.Banana.Active = false
 			g.Wins[g.Current]++
+			g.TotalWins[g.Current]++
+			g.SaveScores()
 			g.startGorillaExplosion(i)
 			return
 		}


### PR DESCRIPTION
## Summary
- track lifetime wins in `Game`
- save and load scores from `gorillas_scores.json`
- show stats when exiting the tcell or ebiten ports

## Testing
- `go build ./...` *(fails: proxy access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c95f82218832fa1649a329a19af3e