### PR TITLE
Add Go vet and test workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,21 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+    - name: Vet
+      run: go vet ./...
+    - name: Test
+      run: go test ./...


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `go vet` and `go test`

## Testing
- `go vet ./...` *(fails: access to proxy.golang.org blocked)*
- `go test ./...` *(fails: access to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c9642cbe8832fa26340e80992abc4