### PR TITLE
Implement persistent scoring

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -39,11 +39,8 @@ type Game struct {
 
 func newGame(settings gorillas.Settings) *Game {
 	g := &Game{Game: gorillas.NewGame(800, 600)}
-<<<<<<< codex/add-optional-sound-playback-feature
 	g.Game.Settings = settings
-=======
 	g.LoadScores()
->>>>>>> master
 	rand.Seed(time.Now().UnixNano())
 	bw := float64(g.Width) / gorillas.BuildingCount
 	for i := 0; i < gorillas.BuildingCount; i++ {

--- a/game_test.go
+++ b/game_test.go
@@ -2,6 +2,7 @@ package gorillas
 
 import (
 	"math"
+	"path/filepath"
 	"testing"
 )
 
@@ -125,5 +126,31 @@ func TestGorillaHitIncrementsWin(t *testing.T) {
 	}
 	if g.Wins[0] != 1 {
 		t.Fatalf("wins should persist after reset, got %v", g.Wins)
+	}
+}
+
+func TestSaveAndLoadScores(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "scores.json")
+	g1 := newTestGame()
+	g1.ScoreFile = tmp
+	g1.TotalWins = [2]int{2, 3}
+	g1.SaveScores()
+
+	g2 := newTestGame()
+	g2.ScoreFile = tmp
+	g2.LoadScores()
+
+	if g2.TotalWins != g1.TotalWins {
+		t.Fatalf("expected %v, got %v", g1.TotalWins, g2.TotalWins)
+	}
+}
+
+func TestStatsString(t *testing.T) {
+	g := newTestGame()
+	g.Wins = [2]int{1, 2}
+	g.TotalWins = [2]int{3, 4}
+	expected := "Session - P1:1 P2:2\nOverall - P1:3 P2:4"
+	if s := g.StatsString(); s != expected {
+		t.Fatalf("unexpected stats string: %q", s)
 	}
 }


### PR DESCRIPTION
## Summary
- fix leftover merge conflict in ebiten main
- add tests for saving/loading scores and StatsString
- persist wins across sessions and show summary on exit

## Testing
- `go test ./...` *(fails: X11 and ALSA missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ca15c2ad4832f934b1537edfe6540