### PR TITLE
Add tests for Game mechanics

### DIFF
--- a/game_test.go
+++ b/game_test.go
@@ -127,3 +127,37 @@ func TestGorillaHitIncrementsWin(t *testing.T) {
 		t.Fatalf("wins should persist after reset, got %v", g.Wins)
 	}
 }
+
+func TestSecondPlayerThrowDirection(t *testing.T) {
+	g := newTestGame()
+	g.Current = 1
+	g.Angle = 30
+	g.Power = 40
+	g.Throw()
+	if g.Banana.VX >= 0 {
+		t.Fatalf("player 2 banana should move left, got vx=%f", g.Banana.VX)
+	}
+}
+
+func TestExplosionProgressAndReset(t *testing.T) {
+	g := newTestGame()
+	g.startGorillaExplosion(0)
+	g.Explosion.radii = []float64{1, 2}
+	if !g.Explosion.Active {
+		t.Fatal("explosion should start active")
+	}
+
+	if g.Explosion.frame != 0 {
+		t.Fatalf("initial explosion frame should be 0, got %d", g.Explosion.frame)
+	}
+
+	g.Step()
+	if g.Explosion.frame != 1 {
+		t.Fatalf("explosion frame should advance, got %d", g.Explosion.frame)
+	}
+
+	g.Step()
+	if g.Explosion.Active {
+		t.Fatal("explosion should finish and deactivate")
+	}
+}

--- a/sound.go
+++ b/sound.go
@@ -1,3 +1,5 @@
+//go:build !test
+
 package gorillas
 
 import (

--- a/sound_stub.go
+++ b/sound_stub.go
@@ -1,0 +1,7 @@
+//go:build test
+
+package gorillas
+
+func PlayBeep() {}
+
+func PlayIntroMusic() {}


### PR DESCRIPTION
## Summary
- add stubbed sound implementation for tests using build tags
- verify Game.Throw direction for player 2
- check explosion frame progression and reset logic

## Testing
- `go vet -tags test ./...` *(fails: missing go.sum entries)*
- `go test -tags test ./...` *(fails for cmd packages due to missing deps, gorillas tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_685ca15f0c5c832f9effeb385cb2f914