### PR TITLE
Add file-based settings loader

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,8 +1,10 @@
 package gorillas
 
 import (
+	"bufio"
 	"os"
 	"strconv"
+	"strings"
 )
 
 // LoadSettings reads configuration from environment variables.
@@ -12,8 +14,60 @@ import (
 //	GORILLAS_SOUND - set to 'true' or 'false' to enable or disable sound.
 //	GORILLAS_OLD_EXPLOSIONS - 'true' to use the old explosion style.
 //	GORILLAS_EXPLOSION_RADIUS - floating point radius for new explosions.
+func loadSettingsFile(path string, s *Settings) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		eq := strings.Index(line, "=")
+		if eq < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:eq])
+		val := strings.TrimSpace(line[eq+1:])
+		switch strings.ToUpper(key) {
+		case "USESOUND":
+			if b, err := strconv.ParseBool(val); err == nil {
+				s.UseSound = b
+			} else if strings.EqualFold(val, "YES") {
+				s.UseSound = true
+			} else if strings.EqualFold(val, "NO") {
+				s.UseSound = false
+			}
+		case "USEOLDEXPLOSIONS":
+			if b, err := strconv.ParseBool(val); err == nil {
+				s.UseOldExplosions = b
+			} else if strings.EqualFold(val, "YES") {
+				s.UseOldExplosions = true
+			} else if strings.EqualFold(val, "NO") {
+				s.UseOldExplosions = false
+			}
+		case "NEWEXPLOSIONRADIUS":
+			if f, err := strconv.ParseFloat(val, 64); err == nil {
+				s.NewExplosionRadius = f
+			}
+		case "DEFAULTGRAVITY":
+			if f, err := strconv.ParseFloat(val, 64); err == nil && f > 0 {
+				s.DefaultGravity = f
+			}
+		case "DEFAULTROUNDQTY":
+			if n, err := strconv.Atoi(val); err == nil && n > 0 {
+				s.DefaultRoundQty = n
+			}
+		}
+	}
+}
+
 func LoadSettings() Settings {
 	s := DefaultSettings()
+	loadSettingsFile("gorillas.ini", &s)
 	if v, ok := os.LookupEnv("GORILLAS_SOUND"); ok {
 		if b, err := strconv.ParseBool(v); err == nil {
 			s.UseSound = b
@@ -27,6 +81,16 @@ func LoadSettings() Settings {
 	if v, ok := os.LookupEnv("GORILLAS_EXPLOSION_RADIUS"); ok {
 		if f, err := strconv.ParseFloat(v, 64); err == nil {
 			s.NewExplosionRadius = f
+		}
+	}
+	if v, ok := os.LookupEnv("GORILLAS_GRAVITY"); ok {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			s.DefaultGravity = f
+		}
+	}
+	if v, ok := os.LookupEnv("GORILLAS_ROUNDS"); ok {
+		if n, err := strconv.Atoi(v); err == nil {
+			s.DefaultRoundQty = n
 		}
 	}
 	return s

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,38 @@
+package gorillas
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadSettingsFile(t *testing.T) {
+	dir := t.TempDir()
+	ini := filepath.Join(dir, "gorillas.ini")
+	data := []byte("" +
+		"UseSound=no\n" +
+		"UseOldExplosions=yes\n" +
+		"NewExplosionRadius=20.5\n" +
+		"DefaultGravity=30\n" +
+		"DefaultRoundQty=7\n")
+	if err := os.WriteFile(ini, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	s := DefaultSettings()
+	loadSettingsFile(ini, &s)
+	if s.UseSound != false {
+		t.Errorf("expected UseSound=false got %v", s.UseSound)
+	}
+	if !s.UseOldExplosions {
+		t.Errorf("expected UseOldExplosions=true")
+	}
+	if s.NewExplosionRadius != 20.5 {
+		t.Errorf("unexpected radius %f", s.NewExplosionRadius)
+	}
+	if s.DefaultGravity != 30 {
+		t.Errorf("unexpected gravity %f", s.DefaultGravity)
+	}
+	if s.DefaultRoundQty != 7 {
+		t.Errorf("unexpected round qty %d", s.DefaultRoundQty)
+	}
+}

--- a/game.go
+++ b/game.go
@@ -27,6 +27,8 @@ type Settings struct {
 	UseSound           bool
 	UseOldExplosions   bool
 	NewExplosionRadius float64
+	DefaultGravity     float64
+	DefaultRoundQty    int
 }
 
 type Explosion struct {
@@ -37,7 +39,12 @@ type Explosion struct {
 }
 
 func DefaultSettings() Settings {
-	return Settings{UseSound: true, NewExplosionRadius: 40}
+	return Settings{
+		UseSound:           true,
+		NewExplosionRadius: 40,
+		DefaultGravity:     17,
+		DefaultRoundQty:    4,
+	}
 }
 
 // LoadScores reads the persistent win totals from disk.


### PR DESCRIPTION
## Summary
- extend `Settings` with gravity and round quantity fields
- implement `loadSettingsFile` and load from `gorillas.ini`
- support environment overrides for gravity and round count
- test loading settings from an ini file

## Testing
- `go test ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_685ca638b8e4832f8c76a8793cf2b2a5