### PR TITLE
Add wind mechanics

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -122,7 +122,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	if g.Explosion.Active {
 		drawFilledCircle(screen, g.Explosion.X, g.Explosion.Y, g.Explosion.radii[g.Explosion.frame], color.RGBA{255, 255, 0, 255})
 	}
-	ebitenutil.DebugPrint(screen, fmt.Sprintf("A:%2.0f P:%2.0f P%d %d-%d", g.Angle, g.Power, g.Current+1, g.Wins[0], g.Wins[1]))
+	ebitenutil.DebugPrint(screen, fmt.Sprintf("A:%2.0f P:%2.0f W:%+2.0f P%d %d-%d", g.Angle, g.Power, g.Wind, g.Current+1, g.Wins[0], g.Wins[1]))
 }
 
 func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -101,7 +101,7 @@ func (g *Game) draw() {
 		}
 	}
 	g.drawSun()
-	s := fmt.Sprintf("A:%2.0f P:%2.0f P%d %d-%d", g.Angle, g.Power, g.Current+1, g.Wins[0], g.Wins[1])
+	s := fmt.Sprintf("A:%2.0f P:%2.0f W:%+2.0f P%d %d-%d", g.Angle, g.Power, g.Wind, g.Current+1, g.Wins[0], g.Wins[1])
 	for i, r := range s {
 		g.screen.SetContent(i, 0, r, nil, tcell.StyleDefault)
 	}

--- a/game.go
+++ b/game.go
@@ -84,6 +84,7 @@ type Game struct {
 	Wins          [2]int
 	TotalWins     [2]int
 	ScoreFile     string
+	Wind          float64
 }
 
 const BuildingCount = 10
@@ -93,6 +94,7 @@ func NewGame(width, height int) *Game {
 	g := &Game{Width: width, Height: height, Angle: 45, Power: 50, ScoreFile: defaultScoreFile}
 	g.Settings = DefaultSettings()
 	rand.Seed(time.Now().UnixNano())
+	g.Wind = float64(rand.Intn(21) - 10)
 	bw := float64(width) / BuildingCount
 
 	// create a sloping skyline similar to the original BASIC version
@@ -213,6 +215,7 @@ func (g *Game) Step() {
 	g.Banana.X += g.Banana.VX
 	g.Banana.Y += g.Banana.VY
 	g.Banana.VY += 0.5
+	g.Banana.VX += g.Wind / 20
 	idx := int(g.Banana.X / (float64(g.Width) / BuildingCount))
 	if idx >= 0 && idx < BuildingCount {
 		if g.Banana.Y > float64(g.Height)-g.Buildings[idx].H {

--- a/game_test.go
+++ b/game_test.go
@@ -9,6 +9,7 @@ import (
 func newTestGame() *Game {
 	g := &Game{Width: 100, Height: 100}
 	g.Settings = DefaultSettings()
+	g.Wind = 0
 	bw := float64(g.Width) / BuildingCount
 	for i := 0; i < BuildingCount; i++ {
 		g.Buildings = append(g.Buildings, Building{X: float64(i) * bw, W: bw, H: 0})
@@ -88,6 +89,22 @@ func TestBuildingCollisionEndsTurn(t *testing.T) {
 	}
 	if g.Current != 1 {
 		t.Fatalf("turn should switch to player 2 after hitting building, got %d", g.Current)
+	}
+}
+
+func TestWindInfluencesVelocity(t *testing.T) {
+	g := newTestGame()
+	g.Angle = 0
+	g.Power = 20
+	g.Current = 0
+	g.Wind = 4
+
+	g.Throw()
+	initialVX := g.Banana.VX
+	g.Step()
+	expectedVX := initialVX + g.Wind/20
+	if !almostEqual(g.Banana.VX, expectedVX) {
+		t.Fatalf("expected vx %f got %f", expectedVX, g.Banana.VX)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `Wind` field to `Game` and randomize it each round
- display wind in the Ebiten and tcell UIs
- apply wind acceleration to banana movement
- test that wind adjusts velocity

## Testing
- `go test ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_685ca63eb980832fa0dbb782f7466673