### PR TITLE
Expose Game gravity setting

### DIFF
--- a/game.go
+++ b/game.go
@@ -92,6 +92,7 @@ type Game struct {
 	TotalWins     [2]int
 	ScoreFile     string
 	Wind          float64
+	Gravity       float64
 }
 
 const BuildingCount = 10
@@ -100,6 +101,7 @@ const defaultScoreFile = "gorillas_scores.json"
 func NewGame(width, height int) *Game {
 	g := &Game{Width: width, Height: height, Angle: 45, Power: 50, ScoreFile: defaultScoreFile}
 	g.Settings = DefaultSettings()
+	g.Gravity = g.Settings.DefaultGravity
 	rand.Seed(time.Now().UnixNano())
 	g.Wind = float64(rand.Intn(21) - 10)
 	bw := float64(width) / BuildingCount
@@ -158,6 +160,7 @@ func (g *Game) Reset() {
 	file := g.ScoreFile
 	*g = *NewGame(g.Width, g.Height)
 	g.Settings = DefaultSettings()
+	g.Gravity = g.Settings.DefaultGravity
 	g.Wins = wins
 	g.TotalWins = totals
 	g.ScoreFile = file
@@ -221,7 +224,7 @@ func (g *Game) Step() {
 	}
 	g.Banana.X += g.Banana.VX
 	g.Banana.Y += g.Banana.VY
-	g.Banana.VY += 0.5
+	g.Banana.VY += g.Gravity / 34
 	g.Banana.VX += g.Wind / 20
 	idx := int(g.Banana.X / (float64(g.Width) / BuildingCount))
 	if idx >= 0 && idx < BuildingCount {

--- a/game_test.go
+++ b/game_test.go
@@ -9,6 +9,7 @@ import (
 func newTestGame() *Game {
 	g := &Game{Width: 100, Height: 100}
 	g.Settings = DefaultSettings()
+	g.Gravity = g.Settings.DefaultGravity
 	g.Wind = 0
 	bw := float64(g.Width) / BuildingCount
 	for i := 0; i < BuildingCount; i++ {
@@ -51,7 +52,7 @@ func TestBananaTrajectoryAndOutOfBounds(t *testing.T) {
 	if !almostEqual(g.Banana.X, startX+vx) || !almostEqual(g.Banana.Y, startY+vy) {
 		t.Fatalf("unexpected position after first step: (%f,%f)", g.Banana.X, g.Banana.Y)
 	}
-	if !almostEqual(g.Banana.VY, vy+0.5) {
+	if !almostEqual(g.Banana.VY, vy+g.Gravity/34) {
 		t.Fatalf("unexpected vy after first step: %f", g.Banana.VY)
 	}
 	if !g.Banana.Active {
@@ -105,6 +106,20 @@ func TestWindInfluencesVelocity(t *testing.T) {
 	expectedVX := initialVX + g.Wind/20
 	if !almostEqual(g.Banana.VX, expectedVX) {
 		t.Fatalf("expected vx %f got %f", expectedVX, g.Banana.VX)
+	}
+}
+
+func TestGravityInfluencesVelocity(t *testing.T) {
+	g := newTestGame()
+	g.Angle = 0
+	g.Power = 20
+	g.Current = 0
+	g.Gravity = 34
+
+	g.Throw()
+	g.Step()
+	if !almostEqual(g.Banana.VY, g.Gravity/34) {
+		t.Fatalf("expected vy %f got %f", g.Gravity/34, g.Banana.VY)
 	}
 }
 
@@ -177,7 +192,7 @@ func TestExplosionProgressAndReset(t *testing.T) {
 	g.Step()
 	if g.Explosion.Active {
 		t.Fatal("explosion should finish and deactivate")
-  }
+	}
 }
 
 func TestSaveAndLoadScores(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `Gravity` field to `Game`
- initialise gravity from settings in `NewGame` and `Reset`
- factor gravity into `Step`
- ensure tests use gravity and add a gravity test

## Testing
- `go test ./...` *(fails: missing go.sum entries and X11 headers)*

------
https://chatgpt.com/codex/tasks/task_e_685ca88db9b4832fbd3b6f83c17b4dc5