### PR TITLE
Add winner-first flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Friday evening gorillas tournaments and beers form a cornerstone of GorillaStack
 ### Development Roadmap
 
 * Optional wind fluctuations on each throw
-* Optional winner's throw first
+* Optional winner's throw first via `-winnerfirst` flag or `GORILLAS_WINNER_FIRST` setting
 * Option to save throw and replay 'Greatest Hits'
 
 
@@ -26,5 +26,6 @@ command-line flags:
   -gravity    gravitational constant
   -rounds     number of rounds to play
   -buildings  how many buildings appear in the skyline
+  -winnerfirst winner of a round starts next
 ```
 

--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -142,6 +142,7 @@ func main() {
 	rounds := flag.Int("rounds", settings.DefaultRoundQty, "round count")
 	buildings := flag.Int("buildings", gorillas.DefaultBuildingCount, "building count")
 	flag.BoolVar(&settings.UseSound, "sound", settings.UseSound, "enable sound")
+	flag.BoolVar(&settings.WinnerFirst, "winnerfirst", settings.WinnerFirst, "winner starts next round")
 	flag.Parse()
 	settings.DefaultGravity = *gravity
 	settings.DefaultRoundQty = *rounds

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -183,6 +183,7 @@ func main() {
 	rounds := flag.Int("rounds", settings.DefaultRoundQty, "round count")
 	buildings := flag.Int("buildings", gorillas.DefaultBuildingCount, "building count")
 	flag.BoolVar(&settings.UseSound, "sound", settings.UseSound, "enable sound")
+	flag.BoolVar(&settings.WinnerFirst, "winnerfirst", settings.WinnerFirst, "winner starts next round")
 	ai := flag.Bool("ai", false, "enable computer opponent")
 	flag.Parse()
 	settings.DefaultGravity = *gravity
@@ -192,7 +193,7 @@ func main() {
 		return
 	}
 
-	g := newGame(settings)
+	g := newGame(settings, *buildings, *wind)
 	if err := g.run(s, *ai); err != nil {
 		panic(err)
 	}

--- a/config.go
+++ b/config.go
@@ -11,9 +11,10 @@ import (
 // The flag package can override these values using its BoolVar API.
 // Recognised variables:
 //
-//	GORILLAS_SOUND - set to 'true' or 'false' to enable or disable sound.
-//	GORILLAS_OLD_EXPLOSIONS - 'true' to use the old explosion style.
-//	GORILLAS_EXPLOSION_RADIUS - floating point radius for new explosions.
+//		GORILLAS_SOUND - set to 'true' or 'false' to enable or disable sound.
+//		GORILLAS_OLD_EXPLOSIONS - 'true' to use the old explosion style.
+//	     GORILLAS_WINNER_FIRST - 'true' if round winner starts the next round.
+//		GORILLAS_EXPLOSION_RADIUS - floating point radius for new explosions.
 func loadSettingsFile(path string, s *Settings) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -61,6 +62,14 @@ func loadSettingsFile(path string, s *Settings) {
 			if n, err := strconv.Atoi(val); err == nil && n > 0 {
 				s.DefaultRoundQty = n
 			}
+		case "WINNERFIRST":
+			if b, err := strconv.ParseBool(val); err == nil {
+				s.WinnerFirst = b
+			} else if strings.EqualFold(val, "YES") {
+				s.WinnerFirst = true
+			} else if strings.EqualFold(val, "NO") {
+				s.WinnerFirst = false
+			}
 		}
 	}
 }
@@ -91,6 +100,11 @@ func LoadSettings() Settings {
 	if v, ok := os.LookupEnv("GORILLAS_ROUNDS"); ok {
 		if n, err := strconv.Atoi(v); err == nil {
 			s.DefaultRoundQty = n
+		}
+	}
+	if v, ok := os.LookupEnv("GORILLAS_WINNER_FIRST"); ok {
+		if b, err := strconv.ParseBool(v); err == nil {
+			s.WinnerFirst = b
 		}
 	}
 	return s

--- a/config_test.go
+++ b/config_test.go
@@ -14,7 +14,8 @@ func TestLoadSettingsFile(t *testing.T) {
 		"UseOldExplosions=yes\n" +
 		"NewExplosionRadius=20.5\n" +
 		"DefaultGravity=30\n" +
-		"DefaultRoundQty=7\n")
+		"DefaultRoundQty=7\n" +
+		"WinnerFirst=yes\n")
 	if err := os.WriteFile(ini, data, 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -34,5 +35,8 @@ func TestLoadSettingsFile(t *testing.T) {
 	}
 	if s.DefaultRoundQty != 7 {
 		t.Errorf("unexpected round qty %d", s.DefaultRoundQty)
+	}
+	if !s.WinnerFirst {
+		t.Errorf("expected WinnerFirst=true")
 	}
 }

--- a/game.go
+++ b/game.go
@@ -29,6 +29,7 @@ type Settings struct {
 	NewExplosionRadius float64
 	DefaultGravity     float64
 	DefaultRoundQty    int
+	WinnerFirst        bool
 }
 
 type Explosion struct {
@@ -44,6 +45,7 @@ func DefaultSettings() Settings {
 		NewExplosionRadius: 40,
 		DefaultGravity:     17,
 		DefaultRoundQty:    4,
+		WinnerFirst:        false,
 	}
 }
 
@@ -218,7 +220,11 @@ func (g *Game) Step() {
 			g.Explosion.Active = false
 			cur := g.Current
 			g.Reset()
-			g.Current = cur
+			if g.Settings.WinnerFirst {
+				g.Current = cur
+			} else {
+				g.Current = (cur + 1) % 2
+			}
 		}
 		return
 	}

--- a/game_test.go
+++ b/game_test.go
@@ -120,6 +120,7 @@ func TestGravityInfluencesVelocity(t *testing.T) {
 
 func TestGorillaHitIncrementsWin(t *testing.T) {
 	g := newTestGame()
+	g.Settings.WinnerFirst = true
 	g.Angle = 45
 	g.Power = 100
 	g.Current = 0
@@ -153,6 +154,28 @@ func TestGorillaHitIncrementsWin(t *testing.T) {
 	}
 	if g.Wins[0] != 1 {
 		t.Fatalf("wins should persist after reset, got %v", g.Wins)
+	}
+}
+
+func TestWinnerFirstDisabled(t *testing.T) {
+	g := newTestGame()
+	g.Angle = 45
+	g.Power = 100
+	g.Current = 0
+
+	startX := g.Gorillas[0].X
+	startY := g.Gorillas[0].Y
+	vx := math.Cos(g.Angle*math.Pi/180) * (g.Power / 2)
+	vy := -math.Sin(g.Angle*math.Pi/180) * (g.Power / 2)
+	g.Gorillas[1] = Gorilla{X: startX + vx, Y: startY + vy}
+
+	g.Throw()
+	g.Step()
+	for g.Explosion.Active {
+		g.Step()
+	}
+	if g.Current != 1 {
+		t.Fatalf("current should switch to player 2 when WinnerFirst is off, got %d", g.Current)
 	}
 }
 


### PR DESCRIPTION
## Summary
- implement `WinnerFirst` option to control who starts a new round
- parse WinnerFirst from settings, env var and command line flags
- document the new option in README
- test parsing and game behaviour

## Testing
- `go test ./...` *(fails: missing X11/ALSA libs)*

------
https://chatgpt.com/codex/tasks/task_e_685cab0956a8832f9bbb4d185f1958dd