### PR TITLE
Add additional settings parsing

### DIFF
--- a/cmd/gorillia-tcell/intro.go
+++ b/cmd/gorillia-tcell/intro.go
@@ -37,7 +37,7 @@ func drawGorillaFrame(s tcell.Screen, x, y int, frame []string) {
 	}
 }
 
-func showIntroMovie(s tcell.Screen, useSound bool) {
+func showIntroMovie(s tcell.Screen, useSound, sliding bool) {
 	w, h := s.Size()
 	lines := []string{
 		"QBasic GORILLAS",
@@ -45,10 +45,20 @@ func showIntroMovie(s tcell.Screen, useSound bool) {
 		"Starring two gorillas",
 	}
 	s.Clear()
-	for i, line := range lines {
-		drawString(s, (w-len(line))/2, h/2-1+i, line)
+	if sliding {
+		for i, line := range lines {
+			for j := 1; j <= len(line); j++ {
+				drawString(s, (w-len(line))/2, h/2-1+i, line[:j])
+				s.Show()
+				time.Sleep(30 * time.Millisecond)
+			}
+		}
+	} else {
+		for i, line := range lines {
+			drawString(s, (w-len(line))/2, h/2-1+i, line)
+		}
+		s.Show()
 	}
-	s.Show()
 	if useSound {
 		gorillas.PlayIntroMusic()
 	}
@@ -62,7 +72,7 @@ func showIntroMovie(s tcell.Screen, useSound bool) {
 	time.Sleep(700 * time.Millisecond)
 }
 
-func introScreen(s tcell.Screen, useSound bool) bool {
+func introScreen(s tcell.Screen, useSound, sliding bool) bool {
 	w, h := s.Size()
 	cx := w/2 - 10
 	cy := h/2 - 2
@@ -91,7 +101,7 @@ func introScreen(s tcell.Screen, useSound bool) bool {
 			case 'p', 'P':
 				return true
 			case 'v', 'V':
-				showIntroMovie(s, useSound)
+				showIntroMovie(s, useSound, sliding)
 			}
 		}
 	}

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -188,11 +188,15 @@ func main() {
 	settings.DefaultGravity = *gravity
 	settings.DefaultRoundQty = *rounds
 
-	if !introScreen(s, settings.UseSound) {
+	if settings.ShowIntro {
+		showIntroMovie(s, settings.UseSound, settings.UseSlidingText)
+	}
+
+	if !introScreen(s, settings.UseSound, settings.UseSlidingText) {
 		return
 	}
 
-	g := newGame(settings)
+	g := newGame(settings, *buildings, *wind)
 	if err := g.run(s, *ai); err != nil {
 		panic(err)
 	}

--- a/config.go
+++ b/config.go
@@ -14,6 +14,11 @@ import (
 //	GORILLAS_SOUND - set to 'true' or 'false' to enable or disable sound.
 //	GORILLAS_OLD_EXPLOSIONS - 'true' to use the old explosion style.
 //	GORILLAS_EXPLOSION_RADIUS - floating point radius for new explosions.
+//	GORILLAS_GRAVITY - gravitational constant used in game physics.
+//	GORILLAS_ROUNDS - default number of rounds to play.
+//	GORILLAS_SLIDING_TEXT - 'true' to enable sliding text effects.
+//	GORILLAS_SHOW_INTRO - 'true' to display the intro sequence.
+//	GORILLAS_FORCE_CGA - 'true' to force CGA mode graphics.
 func loadSettingsFile(path string, s *Settings) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -53,6 +58,14 @@ func loadSettingsFile(path string, s *Settings) {
 			if f, err := strconv.ParseFloat(val, 64); err == nil {
 				s.NewExplosionRadius = f
 			}
+		case "USESLIDINGTEXT":
+			if b, err := strconv.ParseBool(val); err == nil {
+				s.UseSlidingText = b
+			} else if strings.EqualFold(val, "YES") {
+				s.UseSlidingText = true
+			} else if strings.EqualFold(val, "NO") {
+				s.UseSlidingText = false
+			}
 		case "DEFAULTGRAVITY":
 			if f, err := strconv.ParseFloat(val, 64); err == nil && f > 0 {
 				s.DefaultGravity = f
@@ -60,6 +73,22 @@ func loadSettingsFile(path string, s *Settings) {
 		case "DEFAULTROUNDQTY":
 			if n, err := strconv.Atoi(val); err == nil && n > 0 {
 				s.DefaultRoundQty = n
+			}
+		case "SHOWINTRO":
+			if b, err := strconv.ParseBool(val); err == nil {
+				s.ShowIntro = b
+			} else if strings.EqualFold(val, "YES") {
+				s.ShowIntro = true
+			} else if strings.EqualFold(val, "NO") {
+				s.ShowIntro = false
+			}
+		case "FORCECGA":
+			if b, err := strconv.ParseBool(val); err == nil {
+				s.ForceCGA = b
+			} else if strings.EqualFold(val, "YES") {
+				s.ForceCGA = true
+			} else if strings.EqualFold(val, "NO") {
+				s.ForceCGA = false
 			}
 		}
 	}
@@ -91,6 +120,21 @@ func LoadSettings() Settings {
 	if v, ok := os.LookupEnv("GORILLAS_ROUNDS"); ok {
 		if n, err := strconv.Atoi(v); err == nil {
 			s.DefaultRoundQty = n
+		}
+	}
+	if v, ok := os.LookupEnv("GORILLAS_SLIDING_TEXT"); ok {
+		if b, err := strconv.ParseBool(v); err == nil {
+			s.UseSlidingText = b
+		}
+	}
+	if v, ok := os.LookupEnv("GORILLAS_SHOW_INTRO"); ok {
+		if b, err := strconv.ParseBool(v); err == nil {
+			s.ShowIntro = b
+		}
+	}
+	if v, ok := os.LookupEnv("GORILLAS_FORCE_CGA"); ok {
+		if b, err := strconv.ParseBool(v); err == nil {
+			s.ForceCGA = b
 		}
 	}
 	return s

--- a/config_test.go
+++ b/config_test.go
@@ -14,7 +14,10 @@ func TestLoadSettingsFile(t *testing.T) {
 		"UseOldExplosions=yes\n" +
 		"NewExplosionRadius=20.5\n" +
 		"DefaultGravity=30\n" +
-		"DefaultRoundQty=7\n")
+		"DefaultRoundQty=7\n" +
+		"UseSlidingText=yes\n" +
+		"ShowIntro=no\n" +
+		"ForceCGA=yes\n")
 	if err := os.WriteFile(ini, data, 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -34,5 +37,14 @@ func TestLoadSettingsFile(t *testing.T) {
 	}
 	if s.DefaultRoundQty != 7 {
 		t.Errorf("unexpected round qty %d", s.DefaultRoundQty)
+	}
+	if !s.UseSlidingText {
+		t.Errorf("expected UseSlidingText=true")
+	}
+	if s.ShowIntro {
+		t.Errorf("expected ShowIntro=false")
+	}
+	if !s.ForceCGA {
+		t.Errorf("expected ForceCGA=true")
 	}
 }

--- a/game.go
+++ b/game.go
@@ -27,8 +27,11 @@ type Settings struct {
 	UseSound           bool
 	UseOldExplosions   bool
 	NewExplosionRadius float64
+	UseSlidingText     bool
 	DefaultGravity     float64
 	DefaultRoundQty    int
+	ShowIntro          bool
+	ForceCGA           bool
 }
 
 type Explosion struct {
@@ -42,8 +45,11 @@ func DefaultSettings() Settings {
 	return Settings{
 		UseSound:           true,
 		NewExplosionRadius: 40,
+		UseSlidingText:     false,
 		DefaultGravity:     17,
 		DefaultRoundQty:    4,
+		ShowIntro:          true,
+		ForceCGA:           false,
 	}
 }
 
@@ -174,6 +180,9 @@ func (g *Game) startGorillaExplosion(idx int) {
 	base := g.Settings.NewExplosionRadius
 	if base <= 0 {
 		base = 16
+	}
+	if g.Settings.ForceCGA {
+		base /= 2
 	}
 	if g.Settings.UseSound {
 		PlayBeep()

--- a/game_test.go
+++ b/game_test.go
@@ -215,3 +215,16 @@ func TestStatsString(t *testing.T) {
 		t.Fatalf("unexpected stats string: %q", s)
 	}
 }
+
+func TestForceCGAHalvesExplosionRadius(t *testing.T) {
+	g := newTestGame()
+	g.Settings.ForceCGA = true
+	g.Settings.NewExplosionRadius = 20
+	g.startGorillaExplosion(0)
+	if len(g.Explosion.radii) < 2 {
+		t.Fatal("not enough explosion frames")
+	}
+	if g.Explosion.radii[1] != 10 {
+		t.Fatalf("expected radius 10 got %f", g.Explosion.radii[1])
+	}
+}


### PR DESCRIPTION
## Summary
- extend game Settings for sliding text, intro, CGA mode
- parse new settings from gorillas.ini and env vars
- test new INI parsing logic
- wire new settings to intro handling and explosion radius

## Testing
- `go test ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_685cad6a2800832f81c4f7dbeb29d677