### PR TITLE
Implement BASIC-style wind setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Friday evening gorillas tournaments and beers form a cornerstone of GorillaStack
 
 * Optional wind fluctuations on each throw
 * Optional winner's throw first via `-winnerfirst` flag or `GORILLAS_WINNER_FIRST` setting
+* BASIC-style wind each round via `GORILLAS_VARIABLE_WIND` setting
 * Option to save throw and replay 'Greatest Hits'
 
 

--- a/config.go
+++ b/config.go
@@ -1,7 +1,6 @@
 package gorillas
 
 import (
-	"bufio"
 	"os"
 	"strconv"
 	"strings"
@@ -20,6 +19,7 @@ import (
 //	GORILLAS_SHOW_INTRO - 'true' to display the intro sequence.
 //	GORILLAS_FORCE_CGA - 'true' to force CGA mode graphics.
 //	     GORILLAS_WINNER_FIRST - 'true' if round winner starts the next round.
+//	GORILLAS_VARIABLE_WIND - 'true' to mimic BASIC wind changes each round.
 func loadSettingsFile(path string, s *Settings) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -90,6 +90,7 @@ func loadSettingsFile(path string, s *Settings) {
 				s.ForceCGA = true
 			} else if strings.EqualFold(val, "NO") {
 				s.ForceCGA = false
+			}
 		case "WINNERFIRST":
 			if b, err := strconv.ParseBool(val); err == nil {
 				s.WinnerFirst = b
@@ -97,6 +98,14 @@ func loadSettingsFile(path string, s *Settings) {
 				s.WinnerFirst = true
 			} else if strings.EqualFold(val, "NO") {
 				s.WinnerFirst = false
+			}
+		case "VARIABLEWIND":
+			if b, err := strconv.ParseBool(val); err == nil {
+				s.VariableWind = b
+			} else if strings.EqualFold(val, "YES") {
+				s.VariableWind = true
+			} else if strings.EqualFold(val, "NO") {
+				s.VariableWind = false
 			}
 		}
 	}
@@ -148,6 +157,11 @@ func LoadSettings() Settings {
 	if v, ok := os.LookupEnv("GORILLAS_WINNER_FIRST"); ok {
 		if b, err := strconv.ParseBool(v); err == nil {
 			s.WinnerFirst = b
+		}
+	}
+	if v, ok := os.LookupEnv("GORILLAS_VARIABLE_WIND"); ok {
+		if b, err := strconv.ParseBool(v); err == nil {
+			s.VariableWind = b
 		}
 	}
 	return s

--- a/config_test.go
+++ b/config_test.go
@@ -18,7 +18,8 @@ func TestLoadSettingsFile(t *testing.T) {
 		"UseSlidingText=yes\n" +
 		"ShowIntro=no\n" +
 		"ForceCGA=yes\n" +
-		"WinnerFirst=yes\n")
+		"WinnerFirst=yes\n" +
+		"VariableWind=yes\n")
 	if err := os.WriteFile(ini, data, 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -47,8 +48,11 @@ func TestLoadSettingsFile(t *testing.T) {
 	}
 	if !s.ForceCGA {
 		t.Errorf("expected ForceCGA=true")
-  }
+	}
 	if !s.WinnerFirst {
 		t.Errorf("expected WinnerFirst=true")
+	}
+	if !s.VariableWind {
+		t.Errorf("expected VariableWind=true")
 	}
 }

--- a/game.go
+++ b/game.go
@@ -33,6 +33,7 @@ type Settings struct {
 	ShowIntro          bool
 	ForceCGA           bool
 	WinnerFirst        bool
+	VariableWind       bool
 }
 
 type Explosion struct {
@@ -52,6 +53,7 @@ func DefaultSettings() Settings {
 		ShowIntro:          true,
 		ForceCGA:           false,
 		WinnerFirst:        false,
+		VariableWind:       false,
 	}
 }
 
@@ -178,6 +180,18 @@ func (g *Game) Reset() {
 	g.ScoreFile = file
 }
 
+func basicWind() float64 {
+	w := float64(rand.Intn(10) + 1 - 5)
+	if rand.Intn(3) == 0 {
+		if w > 0 {
+			w += float64(rand.Intn(10) + 1)
+		} else {
+			w -= float64(rand.Intn(10) + 1)
+		}
+	}
+	return w
+}
+
 func (g *Game) startGorillaExplosion(idx int) {
 	base := g.Settings.NewExplosionRadius
 	if base <= 0 {
@@ -229,6 +243,9 @@ func (g *Game) Step() {
 			g.Explosion.Active = false
 			cur := g.Current
 			g.Reset()
+			if g.Settings.VariableWind {
+				g.Wind = basicWind()
+			}
 			if g.Settings.WinnerFirst {
 				g.Current = cur
 			} else {


### PR DESCRIPTION
## Summary
- generate new wind using BASIC algorithm when resetting the game
- allow configuring this behaviour via `VariableWind` setting
- document `GORILLAS_VARIABLE_WIND`
- add tests for ini parsing

## Testing
- `go test ./...` *(fails: X11 & pkg-config missing)*

------
https://chatgpt.com/codex/tasks/task_e_685cb1f64824832f92289cc7a7577295