### PR TITLE
Wrap intro and main gameplay

### DIFF
--- a/cmd/gorillia-ebiten/intro.go
+++ b/cmd/gorillia-ebiten/intro.go
@@ -46,9 +46,13 @@ type introGame struct {
 	charIdx  int
 	next     time.Time
 	frame    int
+	done     bool
 }
 
 func (g *introGame) Update() error {
+	if g.done {
+		return nil
+	}
 	now := time.Now()
 	switch g.stage {
 	case 0:
@@ -91,7 +95,7 @@ func (g *introGame) Update() error {
 		}
 	case 3:
 		if now.After(g.next) {
-			return ebiten.Termination
+			g.done = true
 		}
 	}
 	return nil
@@ -136,12 +140,11 @@ func (g *introGame) Layout(outsideWidth, outsideHeight int) (int, int) {
 	return g.width, g.height
 }
 
-func showIntroMovie(useSound, sliding bool) {
-	w, h := ebiten.WindowSize()
+func newIntroGame(w, h int, useSound, sliding bool) *introGame {
 	if w == 0 || h == 0 {
 		w, h = 800, 600
 	}
-	ig := &introGame{
+	return &introGame{
 		useSound: useSound,
 		sliding:  sliding,
 		lines:    []string{"QBasic GORILLAS", "", "Starring two gorillas"},
@@ -149,5 +152,4 @@ func showIntroMovie(useSound, sliding bool) {
 		height:   h,
 		next:     time.Now(),
 	}
-	_ = ebiten.RunGame(ig)
 }

--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -21,6 +21,33 @@ type window struct {
 	x, y, w, h float64
 }
 
+type wrapper struct {
+	intro *introGame
+	main  *Game
+}
+
+func (w *wrapper) Update() error {
+	if w.intro != nil && !w.intro.done {
+		return w.intro.Update()
+	}
+	return w.main.Update()
+}
+
+func (w *wrapper) Draw(screen *ebiten.Image) {
+	if w.intro != nil && !w.intro.done {
+		w.intro.Draw(screen)
+	} else {
+		w.main.Draw(screen)
+	}
+}
+
+func (w *wrapper) Layout(outsideWidth, outsideHeight int) (int, int) {
+	if w.intro != nil && !w.intro.done {
+		return w.intro.Layout(outsideWidth, outsideHeight)
+	}
+	return w.main.Layout(outsideWidth, outsideHeight)
+}
+
 func drawFilledCircle(img *ebiten.Image, cx, cy, r float64, clr color.Color) {
 	for dx := -r; dx <= r; dx++ {
 		for dy := -r; dy <= r; dy++ {
@@ -177,13 +204,14 @@ func main() {
 	flag.Parse()
 	settings.DefaultGravity = *gravity
 	settings.DefaultRoundQty = *rounds
-
+	var ig *introGame
 	if settings.ShowIntro {
-		showIntroMovie(settings.UseSound, settings.UseSlidingText)
+		w, h := ebiten.WindowSize()
+		ig = newIntroGame(w, h, settings.UseSound, settings.UseSlidingText)
 	}
 	game := newGame(settings, *buildings, *wind)
 	game.Players = [2]string{*p1, *p2}
-	if err := ebiten.RunGame(game); err != nil {
+	if err := ebiten.RunGame(&wrapper{intro: ig, main: game}); err != nil {
 		panic(err)
 	}
 	game.SaveScores()


### PR DESCRIPTION
## Summary
- refactor intro game to use a `done` flag and constructor
- implement `wrapper` that runs intro then main game
- update `main` to create a wrapper and run both games

## Testing
- `go test ./...` *(fails: `Xrandr.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cbdf4f750832f872207d8d26fa7e5