### PR TITLE
Add extro closing message

### DIFF
--- a/cmd/gorillia-ebiten/extro.go
+++ b/cmd/gorillia-ebiten/extro.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+)
+
+var extroPhrases = []string{
+	"May the Schwarz be with you!",
+	"Live long and prosper.",
+	"Goodbye!",
+	"So long!",
+	"Adios!",
+}
+
+// showExtro prints a farewell message and waits briefly for user input.
+func showExtro() {
+	fmt.Println("Thank you for playing Gorillas!")
+	fmt.Println(extroPhrases[rand.Intn(len(extroPhrases))])
+
+	reader := bufio.NewReader(os.Stdin)
+	done := make(chan struct{})
+	go func() {
+		reader.ReadString('\n')
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(4 * time.Second):
+	}
+}

--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -188,4 +188,5 @@ func main() {
 	}
 	game.SaveScores()
 	fmt.Println(game.StatsString())
+	showExtro()
 }

--- a/cmd/gorillia-tcell/extro.go
+++ b/cmd/gorillia-tcell/extro.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+var extroPhrases = []string{
+	"May the Schwarz be with you!",
+	"Live long and prosper.",
+	"Goodbye!",
+	"So long!",
+	"Adios!",
+}
+
+// showExtro displays a farewell message and waits briefly for user input.
+func showExtro(s tcell.Screen) {
+	w, h := s.Size()
+	msg := "Thank you for playing Gorillas!"
+	phrase := extroPhrases[rand.Intn(len(extroPhrases))]
+	drawString(s, (w-len(msg))/2, h/2-1, msg)
+	drawString(s, (w-len(phrase))/2, h/2+1, phrase)
+	s.Show()
+	end := time.Now().Add(4 * time.Second)
+	for time.Now().Before(end) {
+		if s.HasPendingEvent() {
+			if _, ok := s.PollEvent().(*tcell.EventKey); ok {
+				return
+			}
+		} else {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -208,4 +208,5 @@ func main() {
 	}
 	g.SaveScores()
 	fmt.Println(g.StatsString())
+	showExtro(s)
 }


### PR DESCRIPTION
## Summary
- port parting phrases from the BASIC version
- show a random farewell message at the end of each command package

## Testing
- `go test ./...` *(fails: X11/ALSA dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685cc6b31b40832f85168d397f57ce33