### PR TITLE
Fix game tests deterministically

### DIFF
--- a/game.go
+++ b/game.go
@@ -193,14 +193,16 @@ func (g *Game) Reset() {
 	file := g.ScoreFile
 	players := g.Players
 	league := g.League
+	settings := g.Settings
+	gravity := g.Gravity
 	*g = *NewGame(g.Width, g.Height, g.BuildingCount)
-	g.Settings = DefaultSettings()
-	g.Gravity = g.Settings.DefaultGravity
 	g.Wins = wins
 	g.TotalWins = totals
 	g.ScoreFile = file
 	g.Players = players
 	g.League = league
+	g.Settings = settings
+	g.Gravity = gravity
 }
 
 func basicWind() float64 {
@@ -242,8 +244,9 @@ func (g *Game) startGorillaExplosion(idx int) {
 
 func (g *Game) startVictoryDance(idx int) {
 	g.Dance = Dance{
-		idx:    idx,
-		frames: []float64{0, -3, 0, -3, 0},
+		idx: idx,
+		// start with a jump and finish before the explosion ends
+		frames: []float64{-3, 0, -3, 0},
 		baseY:  g.Gorillas[idx].Y,
 		Active: true,
 	}
@@ -315,7 +318,9 @@ func (g *Game) Step() {
 	}
 	g.Banana.X += g.Banana.VX
 	g.Banana.Y += g.Banana.VY
-	g.Banana.VY += 0.5 * (g.Settings.DefaultGravity / 17)
+	// apply gravity scaled to the configured constant
+	// default behaviour uses DefaultGravity which equals Gravity initially
+	g.Banana.VY += g.Gravity / 34
 	g.Banana.VX += g.Wind / 20
 	idx := int(g.Banana.X / (float64(g.Width) / float64(g.BuildingCount)))
 	if idx >= 0 && idx < g.BuildingCount {

--- a/game_test.go
+++ b/game_test.go
@@ -2,15 +2,19 @@ package gorillas
 
 import (
 	"math"
+	"math/rand"
 	"path/filepath"
 	"testing"
 )
 
 func newTestGame() *Game {
+	rand.Seed(1)
 	g := NewGame(100, 100, DefaultBuildingCount)
 	g.Settings = DefaultSettings()
 	g.Gravity = g.Settings.DefaultGravity
 	g.Wind = 0
+	// tests expect no persistent league data
+	g.League = nil
 	return g
 }
 


### PR DESCRIPTION
## Summary
- preserve Settings and Gravity when resetting a game
- adjust gravity calculation to use the game's Gravity value
- start victory dance with a jump and finish before the explosion ends
- seed RNG and remove league from test helper so tests are deterministic

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cc729259c832fa31c698ebcabdbec