### PR TITLE
Handle audio init failure

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"os"
 	"sync"
 	"time"
 
@@ -21,6 +22,12 @@ var (
 )
 
 func initAudio() {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, "audio initialization failed: %v\n", r)
+			audioCtx = nil
+		}
+	}()
 	audioCtx = audio.NewContext(sampleRate)
 	n := sampleRate / 10
 	beepSample = make([]byte, n*4)


### PR DESCRIPTION
## Summary
- handle audio init failure with recover()

## Testing
- `go test -tags test ./...` *(fails: banana should deactivate after hitting building)*

------
https://chatgpt.com/codex/tasks/task_e_685cc84a3ae0832f961f972115e583e2