### PR TITLE
Improve league player management

### DIFF
--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -172,10 +172,14 @@ func (g *Game) run(s tcell.Screen, ai bool) error {
 // setupScreen presents an interactive form allowing the player names,
 // round count and gravity to be edited. It returns the updated values
 // once the user presses Escape to start the game.
-func setupScreen(s tcell.Screen, p1, p2 string, rounds int, gravity float64) (string, string, int, float64, bool) {
+func setupScreen(s tcell.Screen, league *gorillas.League, p1, p2 string, rounds int, gravity float64) (string, string, int, float64, bool) {
 	fields := []string{p1, p2, strconv.Itoa(rounds), fmt.Sprintf("%.0f", gravity)}
+	players := league.Names()
 	cur := 0
 	editing := false
+	editingPlayer := -1
+	newPlayer := false
+	oldName := ""
 	for {
 		s.Clear()
 		_, h := s.Size()
@@ -192,6 +196,15 @@ func setupScreen(s tcell.Screen, p1, p2 string, rounds int, gravity float64) (st
 				s.SetContent(2+x, baseY+i, r, nil, style)
 			}
 		}
+		py := baseY + len(labels) + 1
+		drawString(s, 2, py, "Players (n=new r=rename d=del):")
+		for i, name := range players {
+			style := tcell.StyleDefault
+			if cur == len(fields)+i {
+				style = style.Reverse(true)
+			}
+			drawString(s, 4, py+1+i, name)
+		}
 		s.Show()
 
 		ev := s.PollEvent()
@@ -199,21 +212,55 @@ func setupScreen(s tcell.Screen, p1, p2 string, rounds int, gravity float64) (st
 			if editing {
 				switch key.Key() {
 				case tcell.KeyEnter:
+					if editingPlayer >= 0 {
+						name := players[editingPlayer]
+						if newPlayer {
+							league.AddPlayer(name)
+						} else {
+							league.RenamePlayer(oldName, name)
+							if fields[0] == oldName {
+								fields[0] = name
+							}
+							if fields[1] == oldName {
+								fields[1] = name
+							}
+						}
+						league.Save()
+						editingPlayer = -1
+						newPlayer = false
+					}
 					editing = false
 				case tcell.KeyEsc:
+					if editingPlayer >= 0 {
+						if newPlayer {
+							players = players[:len(players)-1]
+						} else {
+							players[editingPlayer] = oldName
+						}
+						editingPlayer = -1
+						newPlayer = false
+					}
 					editing = false
 				case tcell.KeyBackspace, tcell.KeyBackspace2:
-					if len(fields[cur]) > 0 {
+					if editingPlayer >= 0 {
+						if len(players[editingPlayer]) > 0 {
+							players[editingPlayer] = players[editingPlayer][:len(players[editingPlayer])-1]
+						}
+					} else if len(fields[cur]) > 0 {
 						fields[cur] = fields[cur][:len(fields[cur])-1]
 					}
 				default:
 					if key.Rune() != 0 {
-						if cur >= 2 {
-							if key.Rune() >= '0' && key.Rune() <= '9' {
+						if editingPlayer >= 0 {
+							players[editingPlayer] += string(key.Rune())
+						} else {
+							if cur >= 2 {
+								if key.Rune() >= '0' && key.Rune() <= '9' {
+									fields[cur] += string(key.Rune())
+								}
+							} else {
 								fields[cur] += string(key.Rune())
 							}
-						} else {
-							fields[cur] += string(key.Rune())
 						}
 					}
 				}
@@ -233,12 +280,51 @@ func setupScreen(s tcell.Screen, p1, p2 string, rounds int, gravity float64) (st
 				if cur > 0 {
 					cur--
 				} else {
-					cur = len(fields) - 1
+					cur = len(fields) + len(players) - 1
 				}
 			case tcell.KeyDown, tcell.KeyTab:
-				cur = (cur + 1) % len(fields)
+				cur = (cur + 1) % (len(fields) + len(players))
 			case tcell.KeyEnter:
-				editing = true
+				if cur < len(fields) {
+					editing = true
+				} else {
+					editing = true
+					editingPlayer = cur - len(fields)
+					oldName = players[editingPlayer]
+				}
+			case tcell.KeyRune:
+				switch key.Rune() {
+				case 'n':
+					players = append(players, "")
+					cur = len(fields) + len(players) - 1
+					editing = true
+					editingPlayer = cur - len(fields)
+					newPlayer = true
+				case 'd':
+					if cur >= len(fields) {
+						idx := cur - len(fields)
+						name := players[idx]
+						league.DeletePlayer(name)
+						league.Save()
+						players = append(players[:idx], players[idx+1:]...)
+						if fields[0] == name {
+							fields[0] = ""
+						}
+						if fields[1] == name {
+							fields[1] = ""
+						}
+						if cur >= len(fields)+len(players) {
+							cur--
+						}
+					}
+				case 'r':
+					if cur >= len(fields) {
+						editing = true
+						editingPlayer = cur - len(fields)
+						oldName = players[editingPlayer]
+						newPlayer = false
+					}
+				}
 			}
 		}
 	}
@@ -277,8 +363,9 @@ func main() {
 		return
 	}
 
+	league := gorillas.LoadLeague("gorillas.lge")
 	var ok bool
-	*p1, *p2, *rounds, *gravity, ok = setupScreen(s, *p1, *p2, *rounds, *gravity)
+	*p1, *p2, *rounds, *gravity, ok = setupScreen(s, league, *p1, *p2, *rounds, *gravity)
 	if !ok {
 		return
 	}
@@ -287,6 +374,7 @@ func main() {
 
 	g := newGame(settings, *buildings, *wind)
 	g.Players = [2]string{*p1, *p2}
+	g.League = league
 	if err := g.run(s, *ai); err != nil {
 		panic(err)
 	}

--- a/league.go
+++ b/league.go
@@ -21,6 +21,54 @@ type League struct {
 	file    string
 }
 
+// AddPlayer ensures a player exists in the league.
+func (l *League) AddPlayer(name string) {
+	if l == nil {
+		return
+	}
+	if name == "" {
+		return
+	}
+	if _, ok := l.Players[name]; !ok {
+		l.Players[name] = &PlayerStats{}
+	}
+}
+
+// RenamePlayer changes the key for a player's stats.
+func (l *League) RenamePlayer(oldName, newName string) {
+	if l == nil {
+		return
+	}
+	if oldName == newName || newName == "" {
+		return
+	}
+	if ps, ok := l.Players[oldName]; ok {
+		delete(l.Players, oldName)
+		l.Players[newName] = ps
+	}
+}
+
+// DeletePlayer removes a player from the league.
+func (l *League) DeletePlayer(name string) {
+	if l == nil {
+		return
+	}
+	delete(l.Players, name)
+}
+
+// Names returns the list of player names sorted alphabetically.
+func (l *League) Names() []string {
+	if l == nil {
+		return nil
+	}
+	names := make([]string, 0, len(l.Players))
+	for n := range l.Players {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // LoadLeague reads statistics from the given file.
 func LoadLeague(path string) *League {
 	l := &League{Players: map[string]*PlayerStats{}, file: path}


### PR DESCRIPTION
## Summary
- add CRUD helpers to `League`
- extend tcell setup screen to edit players
- reuse league object from setup when starting game

## Testing
- `go test ./...` *(fails: proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685cc93b8228832fa9032928ad12b8d5