### PR TITLE
Display wind arrow during banana flight

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -182,7 +182,27 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		drawFilledCircle(screen, g.Explosion.X, g.Explosion.Y, g.Explosion.Radii[g.Explosion.Frame], color.RGBA{255, 255, 0, 255})
 	}
 	g.drawSun(screen)
+	g.drawWindArrow(screen)
 	ebitenutil.DebugPrint(screen, fmt.Sprintf("A:%2.0f P:%2.0f W:%+2.0f P%d %d-%d", g.Angle, g.Power, g.Wind, g.Current+1, g.Wins[0], g.Wins[1]))
+}
+
+func (g *Game) drawWindArrow(img *ebiten.Image) {
+	if g.Wind == 0 {
+		return
+	}
+	length := g.Wind * 3 * float64(g.Width) / 320
+	y := float64(g.Height) - float64(g.Height)/40
+	x := float64(g.Width) / 2
+	end := x + length
+	ebitenutil.DrawLine(img, x, y, end, y, color.RGBA{255, 255, 0, 255})
+	head := 5.0
+	if length > 0 {
+		ebitenutil.DrawLine(img, end, y, end-head, y-3, color.RGBA{255, 255, 0, 255})
+		ebitenutil.DrawLine(img, end, y, end-head, y+3, color.RGBA{255, 255, 0, 255})
+	} else {
+		ebitenutil.DrawLine(img, end, y, end+head, y-3, color.RGBA{255, 255, 0, 255})
+		ebitenutil.DrawLine(img, end, y, end+head, y+3, color.RGBA{255, 255, 0, 255})
+	}
 }
 
 func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -106,11 +106,39 @@ func (g *Game) draw() {
 		}
 	}
 	g.drawSun()
+	g.drawWindArrow()
 	s := fmt.Sprintf("A:%2.0f P:%2.0f W:%+2.0f P%d %d-%d", g.Angle, g.Power, g.Wind, g.Current+1, g.Wins[0], g.Wins[1])
 	for i, r := range s {
 		g.screen.SetContent(i, 0, r, nil, tcell.StyleDefault)
 	}
 	g.screen.Show()
+}
+
+func (g *Game) drawWindArrow() {
+	if g.Wind == 0 {
+		return
+	}
+	length := int(math.Round(g.Wind * 3 * float64(g.Width) / 320))
+	y := g.Height - 1
+	x := g.Width / 2
+	dir := 1
+	if length < 0 {
+		dir = -1
+	}
+	for i := dir; i != length; i += dir {
+		pos := x + i
+		if pos >= 0 && pos < g.Width {
+			g.screen.SetContent(pos, y, '-', nil, tcell.StyleDefault)
+		}
+	}
+	headX := x + length
+	if headX >= 0 && headX < g.Width {
+		head := '>'
+		if length < 0 {
+			head = '<'
+		}
+		g.screen.SetContent(headX, y, head, nil, tcell.StyleDefault)
+	}
 }
 
 func (g *Game) drawGorilla(idx int) {


### PR DESCRIPTION
## Summary
- show wind direction and strength with a horizontal arrow at screen bottom
- draw ASCII arrow for the tcell port
- draw line arrow for the Ebiten port

## Testing
- `go test -tags test ./...` *(fails: banana collision tests)*

------
https://chatgpt.com/codex/tasks/task_e_685cc94248f4832faf7c0cb69af612be