### PR TITLE
Show league standings at game end

### DIFF
--- a/cmd/gorillia-ebiten/intro.go
+++ b/cmd/gorillia-ebiten/intro.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"image/color"
 	"strings"
 	"time"
@@ -154,9 +155,6 @@ func newIntroGame(w, h int, useSound, sliding bool) *introGame {
 		height:   h,
 		next:     time.Now(),
 	}
-<<<<<<< codex/create-sparklepause-function
-	_ = ebiten.RunGame(ig)
-	SparklePause(nil, 0)
 }
 
 // sparkleGame shows twinkling '*' borders and optional lines of text.
@@ -233,6 +231,15 @@ func SparklePause(lines []string, dur time.Duration) {
 
 func showStats(stats string) {
 	SparklePause(strings.Split(stats, "\n"), 0)
-=======
->>>>>>> master
+}
+
+func showLeague(l *gorillas.League) {
+	if l == nil {
+		return
+	}
+	lines := []string{"Player           Rounds Wins Accuracy"}
+	for _, s := range l.Standings() {
+		lines = append(lines, fmt.Sprintf("%-15s %6d %4d %8.1f", s.Name, s.Rounds, s.Wins, s.Accuracy))
+	}
+	SparklePause(lines, 0)
 }

--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -216,6 +216,9 @@ func main() {
 	}
 	game.SaveScores()
 	showStats(game.StatsString())
+	if game.League != nil {
+		showLeague(game.League)
+	}
 	fmt.Println(game.StatsString())
 	showExtro()
 }

--- a/cmd/gorillia-tcell/intro.go
+++ b/cmd/gorillia-tcell/intro.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -175,6 +176,24 @@ func showStats(s tcell.Screen, stats string) {
 	w, h := s.Size()
 	y := h/2 - len(lines)/2
 	for i, line := range lines {
+		drawString(s, (w-len(line))/2, y+i, line)
+	}
+	s.Show()
+	SparklePause(s, 0)
+}
+
+func showLeague(s tcell.Screen, l *gorillas.League) {
+	if l == nil {
+		return
+	}
+	rows := []string{"Player           Rounds Wins Accuracy"}
+	for _, st := range l.Standings() {
+		rows = append(rows, fmt.Sprintf("%-15s %6d %4d %8.1f", st.Name, st.Rounds, st.Wins, st.Accuracy))
+	}
+	s.Clear()
+	w, h := s.Size()
+	y := h/2 - len(rows)/2
+	for i, line := range rows {
 		drawString(s, (w-len(line))/2, y+i, line)
 	}
 	s.Show()

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -292,6 +292,9 @@ func main() {
 	}
 	g.SaveScores()
 	showStats(s, g.StatsString())
+	if g.League != nil {
+		showLeague(s, g.League)
+	}
 	fmt.Println(g.StatsString())
 	showExtro(s)
 }


### PR DESCRIPTION
## Summary
- fix merge artifacts in ebiten intro
- display league standings in tcell version
- display league standings in ebiten version

## Testing
- `go test ./... -tags test` *(fails: banana should deactivate; player 1 to score)*
- `go vet ./...` *(fails: missing X11 packages)*

------
https://chatgpt.com/codex/tasks/task_e_685cc9405240832fb6b4a20a17e39db0