### PR TITLE
Wrap errors with context

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -232,7 +232,7 @@ func main() {
 	game := newGame(settings, *buildings, *wind)
 	game.Players = [2]string{*p1, *p2}
 	if err := ebiten.RunGame(&wrapper{intro: ig, main: game}); err != nil {
-		panic(err)
+		panic(fmt.Errorf("run game: %w", err))
 	}
 	game.SaveScores()
 	showStats(game.StatsString())

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -362,10 +362,10 @@ func main() {
 	s, err := tcell.NewScreen()
 	if err != nil {
 		log.Printf("Error: %s", err.Error())
-		panic(err)
+		panic(fmt.Errorf("new screen: %w", err))
 	}
 	if err = s.Init(); err != nil {
-		panic(err)
+		panic(fmt.Errorf("screen init: %w", err))
 	}
 	defer s.Fini()
 
@@ -404,7 +404,7 @@ func main() {
 	g.Players = [2]string{*p1, *p2}
 	g.League = league
 	if err := g.run(s, *ai); err != nil {
-		panic(err)
+		panic(fmt.Errorf("run game: %w", err))
 	}
 	g.SaveScores()
 	showStats(s, g.StatsString())

--- a/sound.go
+++ b/sound.go
@@ -46,7 +46,7 @@ func PlayBeep() {
 	if audioCtx != nil {
 		p, err := audioCtx.NewPlayer(bytes.NewReader(beepSample))
 		if err != nil {
-			panic(err)
+			panic(fmt.Errorf("new player: %w", err))
 		}
 		p.Play()
 	} else {


### PR DESCRIPTION
## Summary
- add error wrapping with fmt.Errorf in sound and game entrypoints

## Testing
- `go test ./...` *(fails: X11 and ALSA missing)*

------
https://chatgpt.com/codex/tasks/task_e_685cccf88e18832fb3508802a26b7a62