### PR TITLE
Fix gamepad init errors by raising ulimit

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -210,6 +210,7 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 }
 
 func main() {
+	increaseRLimit()
 	ebiten.SetWindowSize(800, 600)
 	ebiten.SetWindowTitle("Gorillas Ebiten")
 	settings := gorillas.LoadSettings()

--- a/cmd/gorillia-ebiten/rlimit_linux.go
+++ b/cmd/gorillia-ebiten/rlimit_linux.go
@@ -1,0 +1,16 @@
+//go:build linux && !test
+
+package main
+
+import "golang.org/x/sys/unix"
+
+func increaseRLimit() {
+	var r unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &r); err != nil {
+		return
+	}
+	if r.Cur < r.Max {
+		r.Cur = r.Max
+		_ = unix.Setrlimit(unix.RLIMIT_NOFILE, &r)
+	}
+}

--- a/cmd/gorillia-ebiten/rlimit_stub.go
+++ b/cmd/gorillia-ebiten/rlimit_stub.go
@@ -1,0 +1,5 @@
+//go:build !linux && !test
+
+package main
+
+func increaseRLimit() {}


### PR DESCRIPTION
## Summary
- fix 'too many open files' panics by raising the RLIMIT_NOFILE on Linux only

## Testing
- `go test -tags test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cce4a638c832f9a990d441979a6db