### PR TITLE
Add continue prompt after stats

### DIFF
--- a/cmd/gorillia-ebiten/intro.go
+++ b/cmd/gorillia-ebiten/intro.go
@@ -230,7 +230,9 @@ func SparklePause(lines []string, dur time.Duration) {
 }
 
 func showStats(stats string) {
-	SparklePause(strings.Split(stats, "\n"), 0)
+	lines := strings.Split(stats, "\n")
+	lines = append(lines, "", "Press any key to continue")
+	SparklePause(lines, 0)
 }
 
 func showLeague(l *gorillas.League) {
@@ -241,5 +243,6 @@ func showLeague(l *gorillas.League) {
 	for _, s := range l.Standings() {
 		lines = append(lines, fmt.Sprintf("%-15s %6d %4d %8.1f", s.Name, s.Rounds, s.Wins, s.Accuracy))
 	}
+	lines = append(lines, "", "Press any key to continue")
 	SparklePause(lines, 0)
 }

--- a/cmd/gorillia-tcell/intro.go
+++ b/cmd/gorillia-tcell/intro.go
@@ -178,6 +178,8 @@ func showStats(s tcell.Screen, stats string) {
 	for i, line := range lines {
 		drawString(s, (w-len(line))/2, y+i, line)
 	}
+	msg := "Press any key to continue"
+	drawString(s, (w-len(msg))/2, y+len(lines)+1, msg)
 	s.Show()
 	SparklePause(s, 0)
 }
@@ -196,6 +198,8 @@ func showLeague(s tcell.Screen, l *gorillas.League) {
 	for i, line := range rows {
 		drawString(s, (w-len(line))/2, y+i, line)
 	}
+	msg := "Press any key to continue"
+	drawString(s, (w-len(msg))/2, y+len(rows)+1, msg)
 	s.Show()
 	SparklePause(s, 0)
 }


### PR DESCRIPTION
## Summary
- show "Press any key to continue" after displaying stats
- show the same prompt after league standings

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cd0697e80832fa8d98d5d2f655cc2