### PR TITLE
Add colourful explosion animation

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -179,7 +179,11 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		ebitenutil.DrawRect(screen, g.Banana.X-2, g.Banana.Y-2, 4, 4, color.RGBA{255, 255, 0, 255})
 	}
 	if g.Explosion.Active {
-		drawFilledCircle(screen, g.Explosion.X, g.Explosion.Y, g.Explosion.Radii[g.Explosion.Frame], color.RGBA{255, 255, 0, 255})
+		clr := color.RGBA{255, 255, 0, 255}
+		if len(g.Explosion.Colors) > g.Explosion.Frame {
+			clr = color.RGBAModel.Convert(g.Explosion.Colors[g.Explosion.Frame]).(color.RGBA)
+		}
+		drawFilledCircle(screen, g.Explosion.X, g.Explosion.Y, g.Explosion.Radii[g.Explosion.Frame], clr)
 	}
 	g.drawSun(screen)
 	g.drawWindArrow(screen)

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -94,13 +94,22 @@ func (g *Game) draw() {
 		r := int(g.Explosion.Radii[g.Explosion.Frame])
 		ex := int(g.Explosion.X)
 		ey := int(g.Explosion.Y)
+		char := '*'
+		if !g.Settings.UseOldExplosions {
+			chars := []rune{'#', '@', 'O', 'o', '.'}
+			if g.Explosion.Frame < len(chars) {
+				char = chars[g.Explosion.Frame]
+			} else {
+				char = chars[len(chars)-1]
+			}
+		}
 		for dx := -r; dx <= r; dx++ {
 			for dy := -r; dy <= r; dy++ {
 				if dx*dx+dy*dy <= r*r {
 					x := ex + dx
 					y := ey + dy
 					if x >= 0 && x < g.Width && y >= 0 && y < g.Height {
-						g.screen.SetContent(x, y, '*', nil, tcell.StyleDefault)
+						g.screen.SetContent(x, y, char, nil, tcell.StyleDefault)
 					}
 				}
 			}

--- a/game.go
+++ b/game.go
@@ -3,6 +3,7 @@ package gorillas
 import (
 	"encoding/json"
 	"fmt"
+	"image/color"
 	"math"
 	"math/rand"
 	"os"
@@ -38,6 +39,7 @@ type Settings struct {
 type Explosion struct {
 	X, Y   float64
 	Radii  []float64
+	Colors []color.Color
 	Frame  int
 	Active bool
 }
@@ -235,7 +237,15 @@ func (g *Game) startGorillaExplosion(idx int) {
 			g.Explosion.Radii = append(g.Explosion.Radii, float64(i))
 		}
 	} else {
-		g.Explosion.Radii = append(g.Explosion.Radii, base*1.175, base, base*0.9, base*0.6, base*0.45, 0)
+		g.Explosion.Radii = []float64{base * 1.175, base, base * 0.9, base * 0.6, base * 0.45, 0}
+		g.Explosion.Colors = []color.Color{
+			color.RGBA{128, 128, 128, 255},
+			color.RGBA{255, 0, 0, 255},
+			color.RGBA{255, 165, 0, 255},
+			color.RGBA{255, 255, 0, 255},
+			color.RGBA{255, 255, 255, 255},
+			color.Black,
+		}
 	}
 	g.Explosion.Active = true
 }

--- a/game_test.go
+++ b/game_test.go
@@ -217,6 +217,17 @@ func TestExplosionProgressAndReset(t *testing.T) {
 	}
 }
 
+func TestExplosionColorsMatchRadii(t *testing.T) {
+	g := newTestGame()
+	g.startGorillaExplosion(0)
+	if g.Settings.UseOldExplosions {
+		t.Skip("old explosions have no colours")
+	}
+	if len(g.Explosion.Colors) != len(g.Explosion.Radii) {
+		t.Fatalf("colour frames %d do not match radii %d", len(g.Explosion.Colors), len(g.Explosion.Radii))
+	}
+}
+
 func TestSaveAndLoadScores(t *testing.T) {
 	tmp := filepath.Join(t.TempDir(), "scores.json")
 	g1 := newTestGame()


### PR DESCRIPTION
## Summary
- support storing colours for explosion frames
- generate coloured rings in `startGorillaExplosion`
- render fading rings in Ebiten and tcell clients
- test that colour frames match radii

## Testing
- `go test ./...` *(fails: X11 and network issues)*

------
https://chatgpt.com/codex/tasks/task_e_685cd0529898832fa908127af670439a