### PR TITLE
Port BASIC wind generation to Go

### DIFF
--- a/game.go
+++ b/game.go
@@ -134,7 +134,7 @@ func NewGame(width, height, buildingCount int) *Game {
 	g.Players = [2]string{"Player 1", "Player 2"}
 	g.Settings = DefaultSettings()
 	g.Gravity = g.Settings.DefaultGravity
-	g.Wind = float64(rand.Intn(21) - 10)
+	g.Wind = basicWind()
 	bw := float64(width) / float64(g.BuildingCount)
 
 	// create a sloping skyline similar to the original BASIC version
@@ -203,13 +203,17 @@ func (g *Game) Reset() {
 	g.Gravity = gravity
 }
 
+func fnRan(x int) int {
+	return rand.Intn(x) + 1
+}
+
 func basicWind() float64 {
-	w := float64(rand.Intn(10) + 1 - 5)
-	if rand.Intn(3) == 0 {
+	w := float64(fnRan(10) - 5)
+	if fnRan(3) == 1 {
 		if w > 0 {
-			w += float64(rand.Intn(10) + 1)
+			w += float64(fnRan(10))
 		} else {
-			w -= float64(rand.Intn(10) + 1)
+			w -= float64(fnRan(10))
 		}
 	}
 	return w

--- a/game_test.go
+++ b/game_test.go
@@ -74,8 +74,8 @@ func TestBananaTrajectoryAndOutOfBounds(t *testing.T) {
 
 func TestBuildingCollisionEndsTurn(t *testing.T) {
 	g := newTestGame()
-	// make building 2 tall so banana will collide
-	g.Buildings[2].H = 50
+	// make building 2 tall enough to block the banana
+	g.Buildings[2].H = float64(g.Height) - g.Gorillas[0].Y + 5
 
 	g.Angle = 0
 	g.Power = 20
@@ -283,5 +283,32 @@ func TestVictoryDanceStartsOnHit(t *testing.T) {
 	}
 	if g.Gorillas[0].Y != baseY {
 		t.Fatalf("gorilla should return to base position")
+	}
+}
+
+func TestNewGameWindUsesBasicAlgorithm(t *testing.T) {
+	rand.Seed(1)
+	g := NewGame(100, 100, DefaultBuildingCount)
+	if g.Wind != -11 {
+		t.Fatalf("expected wind -11 got %f", g.Wind)
+	}
+}
+
+func TestVariableWindChangesEachRound(t *testing.T) {
+	rand.Seed(1)
+	g := NewGame(100, 100, DefaultBuildingCount)
+	g.Settings = DefaultSettings()
+	g.Settings.VariableWind = true
+	initial := g.Wind
+	// trigger round end immediately
+	g.Explosion = Explosion{Active: true, Radii: []float64{1}}
+	for g.Explosion.Active {
+		g.Step()
+	}
+	if g.Wind == initial {
+		t.Fatalf("wind should change each round")
+	}
+	if g.Wind != 10 {
+		t.Fatalf("expected wind 10 got %f", g.Wind)
 	}
 }


### PR DESCRIPTION
## Summary
- generate wind via `basicWind` on game creation
- implement FNRan behaviour and gust logic
- adjust collision test for variable building height
- test initial and per-round wind calculations

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cd06dd518832fab9c423a26305e32