### PR TITLE
Add wind fluctuation setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Friday evening gorillas tournaments and beers form a cornerstone of GorillaStack
 
 ### Development Roadmap
 
-* Optional wind fluctuations on each throw
+* Optional wind fluctuations on each throw via `GORILLAS_WIND_FLUCT` setting
 * Optional winner's throw first via `-winnerfirst` flag or `GORILLAS_WINNER_FIRST` setting
 * BASIC-style wind each round via `GORILLAS_VARIABLE_WIND` setting
 * Option to save throw and replay 'Greatest Hits'

--- a/config.go
+++ b/config.go
@@ -11,16 +11,17 @@ import (
 // The flag package can override these values using its BoolVar API.
 // Recognised variables:
 //
-//	GORILLAS_SOUND - set to 'true' or 'false' to enable or disable sound.
-//	GORILLAS_OLD_EXPLOSIONS - 'true' to use the old explosion style.
-//	GORILLAS_EXPLOSION_RADIUS - floating point radius for new explosions.
-//	GORILLAS_GRAVITY - gravitational constant used in game physics.
-//	GORILLAS_ROUNDS - default number of rounds to play.
-//	GORILLAS_SLIDING_TEXT - 'true' to enable sliding text effects.
-//	GORILLAS_SHOW_INTRO - 'true' to display the intro sequence.
-//	GORILLAS_FORCE_CGA - 'true' to force CGA mode graphics.
-//	     GORILLAS_WINNER_FIRST - 'true' if round winner starts the next round.
-//	GORILLAS_VARIABLE_WIND - 'true' to mimic BASIC wind changes each round.
+//		GORILLAS_SOUND - set to 'true' or 'false' to enable or disable sound.
+//		GORILLAS_OLD_EXPLOSIONS - 'true' to use the old explosion style.
+//		GORILLAS_EXPLOSION_RADIUS - floating point radius for new explosions.
+//		GORILLAS_GRAVITY - gravitational constant used in game physics.
+//		GORILLAS_ROUNDS - default number of rounds to play.
+//		GORILLAS_SLIDING_TEXT - 'true' to enable sliding text effects.
+//		GORILLAS_SHOW_INTRO - 'true' to display the intro sequence.
+//		GORILLAS_FORCE_CGA - 'true' to force CGA mode graphics.
+//		     GORILLAS_WINNER_FIRST - 'true' if round winner starts the next round.
+//		GORILLAS_VARIABLE_WIND - 'true' to mimic BASIC wind changes each round.
+//	     GORILLAS_WIND_FLUCT - 'true' to vary wind slightly each throw.
 func loadSettingsFile(path string, s *Settings) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -108,6 +109,14 @@ func loadSettingsFile(path string, s *Settings) {
 			} else if strings.EqualFold(val, "NO") {
 				s.VariableWind = false
 			}
+		case "WINDFLUCTUATIONS":
+			if b, err := strconv.ParseBool(val); err == nil {
+				s.WindFluctuations = b
+			} else if strings.EqualFold(val, "YES") {
+				s.WindFluctuations = true
+			} else if strings.EqualFold(val, "NO") {
+				s.WindFluctuations = false
+			}
 		}
 	}
 }
@@ -163,6 +172,11 @@ func LoadSettings() Settings {
 	if v, ok := os.LookupEnv("GORILLAS_VARIABLE_WIND"); ok {
 		if b, err := strconv.ParseBool(v); err == nil {
 			s.VariableWind = b
+		}
+	}
+	if v, ok := os.LookupEnv("GORILLAS_WIND_FLUCT"); ok {
+		if b, err := strconv.ParseBool(v); err == nil {
+			s.WindFluctuations = b
 		}
 	}
 	return s

--- a/config_test.go
+++ b/config_test.go
@@ -19,7 +19,8 @@ func TestLoadSettingsFile(t *testing.T) {
 		"ShowIntro=no\n" +
 		"ForceCGA=yes\n" +
 		"WinnerFirst=yes\n" +
-		"VariableWind=yes\n")
+		"VariableWind=yes\n" +
+		"WindFluctuations=yes\n")
 	if err := os.WriteFile(ini, data, 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -54,5 +55,8 @@ func TestLoadSettingsFile(t *testing.T) {
 	}
 	if !s.VariableWind {
 		t.Errorf("expected VariableWind=true")
+	}
+	if !s.WindFluctuations {
+		t.Errorf("expected WindFluctuations=true")
 	}
 }

--- a/game.go
+++ b/game.go
@@ -33,6 +33,7 @@ type Settings struct {
 	ForceCGA           bool
 	WinnerFirst        bool
 	VariableWind       bool
+	WindFluctuations   bool
 }
 
 type Explosion struct {
@@ -62,6 +63,7 @@ func DefaultSettings() Settings {
 		ForceCGA:           false,
 		WinnerFirst:        false,
 		VariableWind:       false,
+		WindFluctuations:   false,
 	}
 }
 
@@ -274,6 +276,14 @@ func (g *Game) stepVictoryDance() {
 func (g *Game) Throw() {
 	if g.Settings.UseSound {
 		PlayBeep()
+	}
+	if g.Settings.WindFluctuations {
+		g.Wind += float64(rand.Intn(5) - 2)
+		if g.Wind > 10 {
+			g.Wind = 10
+		} else if g.Wind < -10 {
+			g.Wind = -10
+		}
 	}
 	g.Shots[g.Current]++
 	start := g.Gorillas[g.Current]

--- a/game_test.go
+++ b/game_test.go
@@ -108,6 +108,20 @@ func TestWindInfluencesVelocity(t *testing.T) {
 	}
 }
 
+func TestThrowAppliesWindFluctuation(t *testing.T) {
+	g := newTestGame()
+	g.Settings.WindFluctuations = true
+	g.Wind = 5
+	rand.Seed(2)
+	g.Angle = 0
+	g.Power = 20
+	g.Current = 0
+	g.Throw()
+	if g.Wind != 4 {
+		t.Fatalf("expected wind 4 got %f", g.Wind)
+	}
+}
+
 func TestGravityInfluencesVelocity(t *testing.T) {
 	g := newTestGame()
 	g.Angle = 0


### PR DESCRIPTION
## Summary
- add `WindFluctuations` setting with env var `GORILLAS_WIND_FLUCT`
- apply a small random delta to wind whenever `Throw` is called
- document the new flag in README
- update settings parser and tests accordingly
- include a test verifying wind fluctuation logic

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cd0757f70832f8cf8a813867c4328