### PR TITLE
Add victory dance melody

### DIFF
--- a/game.go
+++ b/game.go
@@ -249,9 +249,6 @@ func (g *Game) startVictoryDance(idx int) {
 		Active: true,
 	}
 	g.Dance.frame = 0
-	if g.Settings.UseSound {
-		PlayBeep()
-	}
 }
 
 func (g *Game) stepVictoryDance() {
@@ -267,7 +264,7 @@ func (g *Game) stepVictoryDance() {
 	g.Gorillas[g.Dance.idx].Y = g.Dance.baseY + offset
 	g.Dance.frame++
 	if g.Settings.UseSound {
-		PlayBeep()
+		PlayDanceMelody()
 	}
 }
 

--- a/sound.go
+++ b/sound.go
@@ -60,3 +60,35 @@ func PlayIntroMusic() {
 		time.Sleep(100 * time.Millisecond)
 	}
 }
+
+func playTone(freq float64, dur time.Duration) {
+	audioOnce.Do(initAudio)
+	if audioCtx != nil {
+		n := int(sampleRate*dur/time.Second) + 1
+		buf := make([]byte, n*4)
+		for i := 0; i < n; i++ {
+			v := math.Sin(2 * math.Pi * freq * float64(i) / sampleRate)
+			s := int16(v * 0.3 * 32767)
+			buf[i*4] = byte(s)
+			buf[i*4+1] = byte(s >> 8)
+			buf[i*4+2] = byte(s)
+			buf[i*4+3] = byte(s >> 8)
+		}
+		p, err := audioCtx.NewPlayer(bytes.NewReader(buf))
+		if err != nil {
+			panic(fmt.Errorf("new player: %w", err))
+		}
+		p.Play()
+	} else {
+		fmt.Print("\a")
+	}
+	time.Sleep(dur)
+}
+
+// PlayDanceMelody plays the short tune used during the victory dance.
+func PlayDanceMelody() {
+	notes := []float64{329.63, 349.23, 392.00, 329.63, 349.23, 293.66, 261.63}
+	for _, f := range notes {
+		playTone(f, 100*time.Millisecond)
+	}
+}

--- a/sound_stub.go
+++ b/sound_stub.go
@@ -5,3 +5,5 @@ package gorillas
 func PlayBeep() {}
 
 func PlayIntroMusic() {}
+
+func PlayDanceMelody() {}


### PR DESCRIPTION
## Summary
- add a small tune to accompany the victory dance
- call the melody when the gorilla moves
- keep tests quiet by stubbing the new sound function

## Testing
- `go test ./...` *(fails: Package 'alsa' not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd0379770832f8f174def0e8b7f42