### PR TITLE
Fix intro menu hang and log errors

### DIFF
--- a/cmd/gorillia-ebiten/intro.go
+++ b/cmd/gorillia-ebiten/intro.go
@@ -158,10 +158,10 @@ func newIntroGame(w, h int, useSound, sliding bool) *introGame {
 }
 
 // showIntroMovie runs the introductory animation.
-func showIntroMovie(useSound, sliding bool) {
+func showIntroMovie(useSound, sliding bool) error {
 	w, h := ebiten.WindowSize()
 	ig := newIntroGame(w, h, useSound, sliding)
-	_ = ebiten.RunGame(ig)
+	return ebiten.RunGame(ig)
 }
 
 // introScreenGame implements ebiten.Game for the initial menu.
@@ -197,7 +197,9 @@ func (g *introScreenGame) Update() error {
 				g.play = true
 				return ebiten.Termination
 			case ebiten.KeyV:
-				showIntroMovie(g.useSound, g.sliding)
+				if err := showIntroMovie(g.useSound, g.sliding); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -238,14 +240,16 @@ func (g *introScreenGame) Layout(outsideWidth, outsideHeight int) (int, int) {
 }
 
 // introScreen runs the intro menu and returns true if the player chose to play.
-func introScreen(useSound, sliding bool) bool {
+func introScreen(useSound, sliding bool) (bool, error) {
 	w, h := ebiten.WindowSize()
 	if w == 0 || h == 0 {
 		w, h = 800, 600
 	}
 	ig := &introScreenGame{useSound: useSound, sliding: sliding, width: w, height: h, next: time.Now().Add(300 * time.Millisecond)}
-	_ = ebiten.RunGame(ig)
-	return ig.play
+	if err := ebiten.RunGame(ig); err != nil {
+		return false, err
+	}
+	return ig.play, nil
 }
 
 // sparkleGame shows twinkling '*' borders and optional lines of text.
@@ -311,29 +315,29 @@ func (g *sparkleGame) Layout(outsideWidth, outsideHeight int) (int, int) {
 
 // SparklePause displays a star border for the specified duration. If lines are
 // provided they are shown centred on the screen.
-func SparklePause(lines []string, dur time.Duration) {
+func SparklePause(lines []string, dur time.Duration) error {
 	w, h := ebiten.WindowSize()
 	if w == 0 || h == 0 {
 		w, h = 800, 600
 	}
 	sg := &sparkleGame{lines: lines, width: w, height: h, timeout: dur}
-	_ = ebiten.RunGame(sg)
+	return ebiten.RunGame(sg)
 }
 
-func showStats(stats string) {
+func showStats(stats string) error {
 	lines := strings.Split(stats, "\n")
 	lines = append(lines, "", "Press any key to continue")
-	SparklePause(lines, 0)
+	return SparklePause(lines, 0)
 }
 
-func showLeague(l *gorillas.League) {
+func showLeague(l *gorillas.League) error {
 	if l == nil {
-		return
+		return nil
 	}
 	lines := []string{"Player           Rounds Wins Accuracy"}
 	for _, s := range l.Standings() {
 		lines = append(lines, fmt.Sprintf("%-15s %6d %4d %8.1f", s.Name, s.Rounds, s.Wins, s.Accuracy))
 	}
 	lines = append(lines, "", "Press any key to continue")
-	SparklePause(lines, 0)
+	return SparklePause(lines, 0)
 }

--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -8,6 +8,7 @@ import (
 	"image/color"
 	"math"
 	"math/rand"
+	"os"
 	"strconv"
 	"time"
 
@@ -380,7 +381,9 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 }
 
 func main() {
-	increaseRLimit()
+	if err := increaseRLimit(); err != nil {
+		fmt.Fprintf(os.Stderr, "increase rlimit: %v\n", err)
+	}
 	ebiten.SetWindowSize(800, 600)
 	ebiten.SetWindowTitle("Gorillas Ebiten")
 	settings := gorillas.LoadSettings()
@@ -396,7 +399,11 @@ func main() {
 	settings.DefaultGravity = *gravity
 	settings.DefaultRoundQty = *rounds
 	if settings.ShowIntro {
-		if !introScreen(settings.UseSound, settings.UseSlidingText) {
+		play, err := introScreen(settings.UseSound, settings.UseSlidingText)
+		if err != nil {
+			panic(fmt.Errorf("intro screen: %w", err))
+		}
+		if !play {
 			return
 		}
 	}
@@ -406,9 +413,13 @@ func main() {
 		panic(fmt.Errorf("run game: %w", err))
 	}
 	game.SaveScores()
-	showStats(game.StatsString())
+	if err := showStats(game.StatsString()); err != nil {
+		fmt.Fprintf(os.Stderr, "show stats: %v\n", err)
+	}
 	if game.League != nil {
-		showLeague(game.League)
+		if err := showLeague(game.League); err != nil {
+			fmt.Fprintf(os.Stderr, "show league: %v\n", err)
+		}
 	}
 	fmt.Println(game.StatsString())
 	showExtro()

--- a/cmd/gorillia-ebiten/rlimit_linux.go
+++ b/cmd/gorillia-ebiten/rlimit_linux.go
@@ -4,13 +4,16 @@ package main
 
 import "golang.org/x/sys/unix"
 
-func increaseRLimit() {
+func increaseRLimit() error {
 	var r unix.Rlimit
 	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &r); err != nil {
-		return
+		return err
 	}
 	if r.Cur < r.Max {
 		r.Cur = r.Max
-		_ = unix.Setrlimit(unix.RLIMIT_NOFILE, &r)
+		if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &r); err != nil {
+			return err
+		}
 	}
+	return nil
 }

--- a/cmd/gorillia-ebiten/rlimit_stub.go
+++ b/cmd/gorillia-ebiten/rlimit_stub.go
@@ -2,4 +2,4 @@
 
 package main
 
-func increaseRLimit() {}
+func increaseRLimit() error { return nil }

--- a/game.go
+++ b/game.go
@@ -77,7 +77,9 @@ func (g *Game) LoadScores() {
 	}
 	b, err := os.ReadFile(file)
 	if err == nil {
-		_ = json.Unmarshal(b, &g.TotalWins)
+		if err := json.Unmarshal(b, &g.TotalWins); err != nil {
+			fmt.Fprintf(os.Stderr, "load scores: %v\n", err)
+		}
 	}
 }
 
@@ -89,7 +91,9 @@ func (g *Game) SaveScores() {
 	}
 	b, err := json.Marshal(g.TotalWins)
 	if err == nil {
-		_ = os.WriteFile(file, b, 0644)
+		if err := os.WriteFile(file, b, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "save scores: %v\n", err)
+		}
 	}
 }
 

--- a/league.go
+++ b/league.go
@@ -73,7 +73,9 @@ func (l *League) Names() []string {
 func LoadLeague(path string) *League {
 	l := &League{Players: map[string]*PlayerStats{}, file: path}
 	if b, err := os.ReadFile(path); err == nil {
-		_ = json.Unmarshal(b, &l.Players)
+		if err := json.Unmarshal(b, &l.Players); err != nil {
+			fmt.Fprintf(os.Stderr, "load league: %v\n", err)
+		}
 	}
 	return l
 }
@@ -87,7 +89,9 @@ func (l *League) Save() {
 		return
 	}
 	if b, err := json.Marshal(l.Players); err == nil {
-		_ = os.WriteFile(l.file, b, 0644)
+		if err := os.WriteFile(l.file, b, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "save league: %v\n", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- propagate errors from intro movie and menu helpers
- return errors from rlimit function
- log failures when loading/saving scores and league
- update main to handle returned errors

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cd37c81dc832fbf6bf29ec78ac087