### PR TITLE
Implement abort prompt on escape

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -112,6 +112,9 @@ type Game struct {
 	powerInput  string
 	enteringAng bool
 	enteringPow bool
+	abortPrompt bool
+	resumeAng   bool
+	resumePow   bool
 	bananaLeft  *ebiten.Image
 	bananaRight *ebiten.Image
 	bananaUp    *ebiten.Image

--- a/cmd/gorillia-ebiten/play_state.go
+++ b/cmd/gorillia-ebiten/play_state.go
@@ -15,6 +15,27 @@ import (
 type playState struct{}
 
 func (playState) Update(g *Game) error {
+	if g.abortPrompt {
+		for _, k := range inpututil.AppendJustPressedKeys(nil) {
+			switch k {
+			case ebiten.KeyY:
+				g.State = newScoreState(g.StatsString())
+			case ebiten.KeyN:
+				g.abortPrompt = false
+				if g.resumeAng {
+					g.enteringAng = true
+				}
+				if g.resumePow {
+					g.enteringPow = true
+				}
+				g.angleInput = ""
+				g.powerInput = ""
+				g.resumeAng = false
+				g.resumePow = false
+			}
+		}
+		return nil
+	}
 	if !g.Banana.Active && !g.Explosion.Active {
 		if g.enteringAng || g.enteringPow {
 			for _, k := range inpututil.AppendJustPressedKeys(nil) {
@@ -47,6 +68,9 @@ func (playState) Update(g *Game) error {
 					}
 				case ebiten.KeyEscape:
 					if g.enteringAng || g.enteringPow {
+						g.abortPrompt = true
+						g.resumeAng = g.enteringAng
+						g.resumePow = g.enteringPow
 						g.enteringAng = false
 						g.enteringPow = false
 						g.angleInput = ""
@@ -199,4 +223,10 @@ func (playState) Draw(g *Game, screen *ebiten.Image) {
 		}
 	}
 	ebitenutil.DebugPrint(screen, fmt.Sprintf("A:%3s P:%3s W:%+2.0f P%d %d-%d", angleStr, powerStr, g.Wind, g.Current+1, g.Wins[0], g.Wins[1]))
+	if g.abortPrompt {
+		msg := "Abort game? [Y/N]"
+		x := (g.Width - len(msg)*charW) / 2
+		y := g.Height/2 - charH/2
+		ebitenutil.DebugPrintAt(screen, msg, x, y)
+	}
 }

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"strconv"
 	"time"
+	"unicode"
 
 	"github.com/arran4/gorillas"
 	"github.com/gdamore/tcell/v2"
@@ -29,6 +30,9 @@ type Game struct {
 	powerInput  string
 	enteringAng bool
 	enteringPow bool
+	abortPrompt bool
+	resumeAng   bool
+	resumePow   bool
 	gorillaArt  [][]string
 }
 
@@ -161,6 +165,10 @@ func (g *Game) draw() {
 	for i, r := range s {
 		g.screen.SetContent(i, 0, r, nil, tcell.StyleDefault)
 	}
+	if g.abortPrompt {
+		msg := "Abort game? [Y/N]"
+		drawString(g.screen, (g.Width-len(msg))/2, 1, msg)
+	}
 	g.screen.Show()
 }
 
@@ -234,6 +242,26 @@ func (g *Game) run(s tcell.Screen, ai bool) error {
 
 		ev := s.PollEvent()
 		if key, ok := ev.(*tcell.EventKey); ok {
+			if g.abortPrompt {
+				r := unicode.ToUpper(key.Rune())
+				if r == 'Y' {
+					return nil
+				}
+				if r == 'N' {
+					g.abortPrompt = false
+					if g.resumeAng {
+						g.enteringAng = true
+						g.angleInput = ""
+					}
+					if g.resumePow {
+						g.enteringPow = true
+						g.powerInput = ""
+					}
+					g.resumeAng = false
+					g.resumePow = false
+				}
+				continue
+			}
 			if g.enteringAng || g.enteringPow {
 				switch key.Key() {
 				case tcell.KeyEnter:
@@ -263,6 +291,9 @@ func (g *Game) run(s tcell.Screen, ai bool) error {
 						g.throw()
 					}
 				case tcell.KeyEsc:
+					g.abortPrompt = true
+					g.resumeAng = g.enteringAng
+					g.resumePow = g.enteringPow
 					g.enteringAng = false
 					g.enteringPow = false
 					g.angleInput = ""


### PR DESCRIPTION
## Summary
- add abort prompt handling to both terminal and ebiten ports
- show "Abort game? [Y/N]" when escape is pressed during input
- resume input or exit based on user choice

## Testing
- `go test ./...` *(fails: X11/ALSA dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685cda90d95c832f9f9ec0873b7c062c