### PR TITLE
UI improvements and building damage

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -95,6 +95,36 @@ func createBananaSprites() (left, right, up, down *ebiten.Image) {
 	return
 }
 
+func createGorillaSprite(mask []string, clr color.Color) *ebiten.Image {
+	h := len(mask)
+	w := len(mask[0])
+	img := ebiten.NewImage(w, h)
+	for y, row := range mask {
+		for x, c := range row {
+			if c != '.' {
+				img.Set(x, y, clr)
+			}
+		}
+	}
+	return img
+}
+
+func defaultGorillaSprite() *ebiten.Image {
+	mask := []string{
+		"..##..",
+		".####.",
+		"######",
+		"##..##",
+		"######",
+		"######",
+		"##..##",
+		"##..##",
+		".#..#.",
+		".####.",
+	}
+	return createGorillaSprite(mask, color.RGBA{150, 75, 0, 255})
+}
+
 type building struct {
 	x, w, h float64
 	color   color.Color
@@ -117,6 +147,7 @@ type Game struct {
 	bananaRight *ebiten.Image
 	bananaUp    *ebiten.Image
 	bananaDown  *ebiten.Image
+	gorillaImg  *ebiten.Image
 	gorillaArt  [][]string
 	State       State
 }
@@ -132,6 +163,7 @@ func newGame(settings gorillas.Settings, buildings int, wind float64) *Game {
 	} else {
 		g.gorillaArt = [][]string{{" O ", "/|\\", "/ \\"}}
 	}
+	g.gorillaImg = defaultGorillaSprite()
 	g.LoadScores()
 	rand.Seed(time.Now().UnixNano())
 	bw := float64(g.Width) / float64(g.Game.BuildingCount)
@@ -172,6 +204,13 @@ func (g *Game) Draw(screen *ebiten.Image) {
 }
 
 func (g *Game) drawGorilla(img *ebiten.Image, idx int) {
+	if g.gorillaImg != nil {
+		op := &ebiten.DrawImageOptions{}
+		w, h := g.gorillaImg.Size()
+		op.GeoM.Translate(g.Gorillas[idx].X-float64(w)/2, g.Gorillas[idx].Y-float64(h))
+		img.DrawImage(g.gorillaImg, op)
+		return
+	}
 	if len(g.gorillaArt) == 0 {
 		gr := g.Gorillas[idx]
 		ebitenutil.DrawRect(img, gr.X-5, gr.Y-10, 10, 10, color.RGBA{255, 0, 0, 255})

--- a/cmd/gorillia-ebiten/play_state.go
+++ b/cmd/gorillia-ebiten/play_state.go
@@ -188,6 +188,9 @@ func (playState) Update(g *Game) error {
 
 func (playState) Draw(g *Game, screen *ebiten.Image) {
 	screen.Fill(color.RGBA{0, 0, 0, 255})
+	for i := range g.buildings {
+		g.buildings[i].h = g.Buildings[i].H
+	}
 	for i, b := range g.buildings {
 		ebitenutil.DrawRect(screen, b.x, float64(g.Height)-b.h, b.w-1, b.h, b.color)
 		for _, w := range b.windows {
@@ -256,7 +259,9 @@ func (playState) Draw(g *Game, screen *ebiten.Image) {
 			powerStr = g.powerInput
 		}
 	}
-	ebitenutil.DebugPrint(screen, fmt.Sprintf("A:%3s P:%3s W:%+2.0f P%d %d-%d", angleStr, powerStr, g.Wind, g.Current+1, g.Wins[0], g.Wins[1]))
+	info := fmt.Sprintf("Player %d (%s) - Angle:%s° Power:%s Wind:%+2.0f Score:%d-%d",
+		g.Current+1, g.Players[g.Current], angleStr, powerStr, g.Wind, g.Wins[0], g.Wins[1])
+	ebitenutil.DebugPrint(screen, info)
 	if g.abortPrompt {
 		msg := "Abort game? [Y/N]"
 		x := (g.Width - len(msg)*charW) / 2

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -89,6 +89,9 @@ func (g *Game) drawSun() {
 
 func (g *Game) draw() {
 	g.screen.Clear()
+	for i := range g.buildings {
+		g.buildings[i].h = int(g.Buildings[i].H)
+	}
 	for i, b := range g.buildings {
 		x := i*buildingWidth + 4
 		for y := g.Height - 1; y >= g.Height-b.h; y-- {
@@ -162,10 +165,9 @@ func (g *Game) draw() {
 			powerStr = g.powerInput
 		}
 	}
-	s := fmt.Sprintf("A:%3s P:%3s W:%+2.0f P%d %d-%d", angleStr, powerStr, g.Wind, g.Current+1, g.Wins[0], g.Wins[1])
-	for i, r := range s {
-		g.screen.SetContent(i, 0, r, nil, tcell.StyleDefault)
-	}
+	info := fmt.Sprintf("Player %d (%s) - Angle:%s° Power:%s Wind:%+2.0f Score:%d-%d",
+		g.Current+1, g.Players[g.Current], angleStr, powerStr, g.Wind, g.Wins[0], g.Wins[1])
+	drawString(g.screen, 0, 0, info)
 	if g.abortPrompt {
 		msg := "Abort game? [Y/N]"
 		drawString(g.screen, (g.Width-len(msg))/2, 1, msg)

--- a/game.go
+++ b/game.go
@@ -349,9 +349,19 @@ func (g *Game) Step() {
 	// default behaviour uses DefaultGravity which equals Gravity initially
 	g.Banana.VY += g.Gravity / 34
 	g.Banana.VX += g.Wind / 20
-	idx := int(g.Banana.X / (float64(g.Width) / float64(g.BuildingCount)))
+	bw := float64(g.Width) / float64(g.BuildingCount)
+	idx := int(g.Banana.X / bw)
 	if idx >= 0 && idx < g.BuildingCount {
 		if g.Banana.Y > float64(g.Height)-g.Buildings[idx].H {
+			// shorten the building to the impact point to simulate
+			// simple environmental destruction
+			newH := float64(g.Height) - g.Banana.Y
+			if newH < 0 {
+				newH = 0
+			}
+			if newH < g.Buildings[idx].H {
+				g.Buildings[idx].H = newH
+			}
 			g.Banana.Active = false
 			g.Current = (g.Current + 1) % 2
 		}

--- a/game_test.go
+++ b/game_test.go
@@ -92,6 +92,26 @@ func TestBuildingCollisionEndsTurn(t *testing.T) {
 	}
 }
 
+func TestBuildingDamageReducesHeight(t *testing.T) {
+	g := newTestGame()
+	// ensure building 2 is tall and track initial height
+	idx := 2
+	g.Buildings[idx].H = float64(g.Height) - g.Gorillas[0].Y + 10
+	initial := g.Buildings[idx].H
+
+	// aim directly at the side of building 2
+	g.Angle = 0
+	g.Power = 20
+	g.Current = 0
+
+	g.Throw()
+	g.Step()
+
+	if g.Buildings[idx].H >= initial {
+		t.Fatalf("expected building height to decrease, got %f", g.Buildings[idx].H)
+	}
+}
+
 func TestWindInfluencesVelocity(t *testing.T) {
 	g := newTestGame()
 	g.Angle = 0


### PR DESCRIPTION
## Summary
- add simple building damage on banana impact
- improve scoreboard text in both UI variants
- render gorillas with a basic sprite in Ebiten
- keep banana drawing behavior
- add test for building damage

## Testing
- `go test -tags test $(go list ./... | grep -v gorillia-ebiten)`

------
https://chatgpt.com/codex/tasks/task_e_685cdcbee6a4832fb9ab6ba771f2b539