### PR TITLE
Fix editing state panic

### DIFF
--- a/cmd/gorillia-ebiten/setup_state.go
+++ b/cmd/gorillia-ebiten/setup_state.go
@@ -25,9 +25,10 @@ type setupState struct {
 
 func newSetupState(g *Game) *setupState {
 	s := &setupState{
-		game:    g,
-		fields:  []string{g.Players[0], g.Players[1], strconv.Itoa(g.Settings.DefaultRoundQty), fmt.Sprintf("%.0f", g.Settings.DefaultGravity)},
-		players: g.League.Names(),
+		game:          g,
+		fields:        []string{g.Players[0], g.Players[1], strconv.Itoa(g.Settings.DefaultRoundQty), fmt.Sprintf("%.0f", g.Settings.DefaultGravity)},
+		players:       g.League.Names(),
+		editingPlayer: -1,
 	}
 	s.updateAssignField()
 	return s
@@ -155,6 +156,7 @@ func (s *setupState) Update(g *Game) error {
 				s.cur = s.assignField
 			} else if s.cur < len(s.fields) {
 				s.editing = true
+				s.editingPlayer = -1
 			} else {
 				s.editing = true
 				s.editingPlayer = s.cur - len(s.fields)


### PR DESCRIPTION
## Summary
- avoid invalid index when editing fields
- clear editingPlayer when editing fields

## Testing
- `go test ./...` *(fails: missing X11 dependencies)*
- `go test -tags test ./...` *(fails: missing X11 dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ce3b22378832f833bdffd9f14208a