### PR TITLE
Chip away at the sun with each hit

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -17,6 +17,7 @@ import (
 )
 
 const sunRadius = 20
+const sunMaxIntegrity = 4
 
 type window struct {
 	x, y, w, h float64
@@ -33,11 +34,15 @@ func drawFilledCircle(img *ebiten.Image, cx, cy, r float64, clr color.Color) {
 }
 
 func (g *Game) drawSun(img *ebiten.Image) {
+	if g.sunIntegrity <= 0 {
+		return
+	}
 	clr := color.RGBA{255, 255, 0, 255}
 	if g.sunHitTicks > 0 {
 		clr = color.RGBA{255, 100, 100, 255}
 	}
-	drawFilledCircle(img, g.sunX, g.sunY, sunRadius, clr)
+	r := float64(g.sunIntegrity) * sunRadius / sunMaxIntegrity
+	drawFilledCircle(img, g.sunX, g.sunY, r, clr)
 	ebitenutil.DrawRect(img, g.sunX-6, g.sunY-4, 3, 3, color.Black)
 	ebitenutil.DrawRect(img, g.sunX+3, g.sunY-4, 3, 3, color.Black)
 	if g.sunHitTicks > 0 {
@@ -133,23 +138,24 @@ type building struct {
 
 type Game struct {
 	*gorillas.Game
-	buildings   []building
-	sunX, sunY  float64
-	sunHitTicks int
-	angleInput  string
-	powerInput  string
-	enteringAng bool
-	enteringPow bool
-	abortPrompt bool
-	resumeAng   bool
-	resumePow   bool
-	bananaLeft  *ebiten.Image
-	bananaRight *ebiten.Image
-	bananaUp    *ebiten.Image
-	bananaDown  *ebiten.Image
-	gorillaImg  *ebiten.Image
-	gorillaArt  [][]string
-	State       State
+	buildings    []building
+	sunX, sunY   float64
+	sunHitTicks  int
+	sunIntegrity int
+	angleInput   string
+	powerInput   string
+	enteringAng  bool
+	enteringPow  bool
+	abortPrompt  bool
+	resumeAng    bool
+	resumePow    bool
+	bananaLeft   *ebiten.Image
+	bananaRight  *ebiten.Image
+	bananaUp     *ebiten.Image
+	bananaDown   *ebiten.Image
+	gorillaImg   *ebiten.Image
+	gorillaArt   [][]string
+	State        State
 }
 
 func newGame(settings gorillas.Settings, buildings int, wind float64) *Game {
@@ -186,6 +192,10 @@ func newGame(settings gorillas.Settings, buildings int, wind float64) *Game {
 	}
 	g.sunX = float64(g.Width) - 40
 	g.sunY = 40
+	g.sunIntegrity = sunMaxIntegrity
+	g.Game.ResetHook = func() {
+		g.sunIntegrity = sunMaxIntegrity
+	}
 	g.bananaLeft, g.bananaRight, g.bananaUp, g.bananaDown = createBananaSprites()
 	return g
 }

--- a/cmd/gorillia-ebiten/play_state.go
+++ b/cmd/gorillia-ebiten/play_state.go
@@ -173,10 +173,14 @@ func (playState) Update(g *Game) error {
 		}
 	} else {
 		g.Step()
-		if g.Banana.Active {
-			if g.Banana.X >= g.sunX-sunRadius && g.Banana.X <= g.sunX+sunRadius &&
-				g.Banana.Y >= g.sunY-sunRadius && g.Banana.Y <= g.sunY+sunRadius {
+		if g.Banana.Active && g.sunIntegrity > 0 {
+			r := float64(g.sunIntegrity) * sunRadius / sunMaxIntegrity
+			if g.Banana.X >= g.sunX-r && g.Banana.X <= g.sunX+r &&
+				g.Banana.Y >= g.sunY-r && g.Banana.Y <= g.sunY+r {
 				g.sunHitTicks = 10
+				if g.sunIntegrity > 0 {
+					g.sunIntegrity--
+				}
 			}
 		}
 	}

--- a/game.go
+++ b/game.go
@@ -129,6 +129,7 @@ type Game struct {
 	Wind          float64
 	BuildingCount int
 	Gravity       float64
+	ResetHook     func()
 }
 
 const DefaultBuildingCount = 10
@@ -211,6 +212,9 @@ func (g *Game) Reset() {
 	g.League = league
 	g.Settings = settings
 	g.Gravity = gravity
+	if g.ResetHook != nil {
+		g.ResetHook()
+	}
 }
 
 func fnRan(x int) int {


### PR DESCRIPTION
## Summary
- allow game engine to notify extra state on reset
- track sun integrity in both frontends
- reduce sun radius/shape on each hit
- reset sun integrity every round

## Testing
- `go test ./...` *(fails: X11 and pkg-config not available)*

------
https://chatgpt.com/codex/tasks/task_e_685ce574abd0832fa084cc58bbaf7db1