### PR TITLE
Add vector explosion option

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -32,6 +32,17 @@ func drawFilledCircle(img *ebiten.Image, cx, cy, r float64, clr color.Color) {
 	}
 }
 
+func drawVectorLines(img *ebiten.Image, pts []gorillas.VectorPoint, clr color.Color) {
+	if len(pts) == 0 {
+		return
+	}
+	prev := pts[0]
+	for _, p := range pts[1:] {
+		ebitenutil.DrawLine(img, prev.X, prev.Y, p.X, p.Y, clr)
+		prev = p
+	}
+}
+
 func (g *Game) drawSun(img *ebiten.Image) {
 	clr := color.RGBA{255, 255, 0, 255}
 	if g.sunHitTicks > 0 {

--- a/cmd/gorillia-ebiten/play_state.go
+++ b/cmd/gorillia-ebiten/play_state.go
@@ -239,7 +239,12 @@ func (playState) Draw(g *Game, screen *ebiten.Image) {
 		if len(g.Explosion.Colors) > g.Explosion.Frame {
 			clr = color.RGBAModel.Convert(g.Explosion.Colors[g.Explosion.Frame]).(color.RGBA)
 		}
-		drawFilledCircle(screen, g.Explosion.X, g.Explosion.Y, g.Explosion.Radii[g.Explosion.Frame], clr)
+		frame := g.Explosion.Frame
+		if g.Settings.UseVectorExplosions && frame > 0 && frame-1 < len(g.Explosion.Vectors) {
+			drawVectorLines(screen, g.Explosion.Vectors[frame-1], clr)
+		} else {
+			drawFilledCircle(screen, g.Explosion.X, g.Explosion.Y, g.Explosion.Radii[frame], clr)
+		}
 	}
 	g.drawSun(screen)
 	g.drawWindArrow(screen)

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -39,6 +39,48 @@ type Game struct {
 
 const buildingWidth = 8
 
+func drawLine(s tcell.Screen, x0, y0, x1, y1 int, r rune) {
+	dx := abs(x1 - x0)
+	dy := -abs(y1 - y0)
+	sx := -1
+	if x0 < x1 {
+		sx = 1
+	}
+	sy := -1
+	if y0 < y1 {
+		sy = 1
+	}
+	err := dx + dy
+	for {
+		s.SetContent(x0, y0, r, nil, tcell.StyleDefault)
+		if x0 == x1 && y0 == y1 {
+			break
+		}
+		e2 := 2 * err
+		if e2 >= dy {
+			if x0 == x1 {
+				break
+			}
+			err += dy
+			x0 += sx
+		}
+		if e2 <= dx {
+			if y0 == y1 {
+				break
+			}
+			err += dx
+			y0 += sy
+		}
+	}
+}
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
 func newGame(settings gorillas.Settings, buildings int, wind float64) *Game {
 	g := &Game{Game: gorillas.NewGame(80, 24, buildings)}
 	if !math.IsNaN(wind) {
@@ -123,9 +165,6 @@ func (g *Game) draw() {
 		g.screen.SetContent(int(g.Banana.X), int(g.Banana.Y), ch, nil, tcell.StyleDefault)
 	}
 	if g.Explosion.Active {
-		r := int(g.Explosion.Radii[g.Explosion.Frame])
-		ex := int(g.Explosion.X)
-		ey := int(g.Explosion.Y)
 		char := '*'
 		if !g.Settings.UseOldExplosions {
 			chars := []rune{'#', '@', 'O', 'o', '.'}
@@ -135,13 +174,24 @@ func (g *Game) draw() {
 				char = chars[len(chars)-1]
 			}
 		}
-		for dx := -r; dx <= r; dx++ {
-			for dy := -r; dy <= r; dy++ {
-				if dx*dx+dy*dy <= r*r {
-					x := ex + dx
-					y := ey + dy
-					if x >= 0 && x < g.Width && y >= 0 && y < g.Height {
-						g.screen.SetContent(x, y, char, nil, tcell.StyleDefault)
+		frame := g.Explosion.Frame
+		if g.Settings.UseVectorExplosions && frame > 0 && frame-1 < len(g.Explosion.Vectors) {
+			pts := g.Explosion.Vectors[frame-1]
+			for i := 1; i < len(pts); i++ {
+				drawLine(g.screen, int(pts[i-1].X), int(pts[i-1].Y), int(pts[i].X), int(pts[i].Y), char)
+			}
+		} else {
+			r := int(g.Explosion.Radii[frame])
+			ex := int(g.Explosion.X)
+			ey := int(g.Explosion.Y)
+			for dx := -r; dx <= r; dx++ {
+				for dy := -r; dy <= r; dy++ {
+					if dx*dx+dy*dy <= r*r {
+						x := ex + dx
+						y := ey + dy
+						if x >= 0 && x < g.Width && y >= 0 && y < g.Height {
+							g.screen.SetContent(x, y, char, nil, tcell.StyleDefault)
+						}
 					}
 				}
 			}

--- a/config.go
+++ b/config.go
@@ -11,17 +11,18 @@ import (
 // The flag package can override these values using its BoolVar API.
 // Recognised variables:
 //
-//		GORILLAS_SOUND - set to 'true' or 'false' to enable or disable sound.
-//		GORILLAS_OLD_EXPLOSIONS - 'true' to use the old explosion style.
-//		GORILLAS_EXPLOSION_RADIUS - floating point radius for new explosions.
-//		GORILLAS_GRAVITY - gravitational constant used in game physics.
-//		GORILLAS_ROUNDS - default number of rounds to play.
-//		GORILLAS_SLIDING_TEXT - 'true' to enable sliding text effects.
-//		GORILLAS_SHOW_INTRO - 'true' to display the intro sequence.
-//		GORILLAS_FORCE_CGA - 'true' to force CGA mode graphics.
-//		     GORILLAS_WINNER_FIRST - 'true' if round winner starts the next round.
-//		GORILLAS_VARIABLE_WIND - 'true' to mimic BASIC wind changes each round.
-//	     GORILLAS_WIND_FLUCT - 'true' to vary wind slightly each throw.
+//			GORILLAS_SOUND - set to 'true' or 'false' to enable or disable sound.
+//			GORILLAS_OLD_EXPLOSIONS - 'true' to use the old explosion style.
+//			GORILLAS_EXPLOSION_RADIUS - floating point radius for new explosions.
+//	          GORILLAS_VECTOR_EXPLOSIONS - 'true' to use vector explosions.
+//			GORILLAS_GRAVITY - gravitational constant used in game physics.
+//			GORILLAS_ROUNDS - default number of rounds to play.
+//			GORILLAS_SLIDING_TEXT - 'true' to enable sliding text effects.
+//			GORILLAS_SHOW_INTRO - 'true' to display the intro sequence.
+//			GORILLAS_FORCE_CGA - 'true' to force CGA mode graphics.
+//			     GORILLAS_WINNER_FIRST - 'true' if round winner starts the next round.
+//			GORILLAS_VARIABLE_WIND - 'true' to mimic BASIC wind changes each round.
+//		     GORILLAS_WIND_FLUCT - 'true' to vary wind slightly each throw.
 func loadSettingsFile(path string, s *Settings) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -56,6 +57,14 @@ func loadSettingsFile(path string, s *Settings) {
 				s.UseOldExplosions = true
 			} else if strings.EqualFold(val, "NO") {
 				s.UseOldExplosions = false
+			}
+		case "USEVECTOREXPLOSIONS":
+			if b, err := strconv.ParseBool(val); err == nil {
+				s.UseVectorExplosions = b
+			} else if strings.EqualFold(val, "YES") {
+				s.UseVectorExplosions = true
+			} else if strings.EqualFold(val, "NO") {
+				s.UseVectorExplosions = false
 			}
 		case "NEWEXPLOSIONRADIUS":
 			if f, err := strconv.ParseFloat(val, 64); err == nil {
@@ -132,6 +141,11 @@ func LoadSettings() Settings {
 	if v, ok := os.LookupEnv("GORILLAS_OLD_EXPLOSIONS"); ok {
 		if b, err := strconv.ParseBool(v); err == nil {
 			s.UseOldExplosions = b
+		}
+	}
+	if v, ok := os.LookupEnv("GORILLAS_VECTOR_EXPLOSIONS"); ok {
+		if b, err := strconv.ParseBool(v); err == nil {
+			s.UseVectorExplosions = b
 		}
 	}
 	if v, ok := os.LookupEnv("GORILLAS_EXPLOSION_RADIUS"); ok {

--- a/config_test.go
+++ b/config_test.go
@@ -20,7 +20,8 @@ func TestLoadSettingsFile(t *testing.T) {
 		"ForceCGA=yes\n" +
 		"WinnerFirst=yes\n" +
 		"VariableWind=yes\n" +
-		"WindFluctuations=yes\n")
+		"WindFluctuations=yes\n" +
+		"UseVectorExplosions=yes\n")
 	if err := os.WriteFile(ini, data, 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -58,5 +59,8 @@ func TestLoadSettingsFile(t *testing.T) {
 	}
 	if !s.WindFluctuations {
 		t.Errorf("expected WindFluctuations=true")
+	}
+	if !s.UseVectorExplosions {
+		t.Errorf("expected UseVectorExplosions=true")
 	}
 }

--- a/game.go
+++ b/game.go
@@ -24,25 +24,27 @@ type Banana struct {
 }
 
 type Settings struct {
-	UseSound           bool
-	UseOldExplosions   bool
-	NewExplosionRadius float64
-	UseSlidingText     bool
-	DefaultGravity     float64
-	DefaultRoundQty    int
-	ShowIntro          bool
-	ForceCGA           bool
-	WinnerFirst        bool
-	VariableWind       bool
-	WindFluctuations   bool
+	UseSound            bool
+	UseOldExplosions    bool
+	UseVectorExplosions bool
+	NewExplosionRadius  float64
+	UseSlidingText      bool
+	DefaultGravity      float64
+	DefaultRoundQty     int
+	ShowIntro           bool
+	ForceCGA            bool
+	WinnerFirst         bool
+	VariableWind        bool
+	WindFluctuations    bool
 }
 
 type Explosion struct {
-	X, Y   float64
-	Radii  []float64
-	Colors []color.Color
-	Frame  int
-	Active bool
+	X, Y    float64
+	Radii   []float64
+	Colors  []color.Color
+	Vectors [][]VectorPoint
+	Frame   int
+	Active  bool
 }
 
 // Dance holds temporary state for the winner's victory animation.
@@ -56,16 +58,17 @@ type Dance struct {
 
 func DefaultSettings() Settings {
 	return Settings{
-		UseSound:           true,
-		NewExplosionRadius: 40,
-		UseSlidingText:     false,
-		DefaultGravity:     17,
-		DefaultRoundQty:    4,
-		ShowIntro:          true,
-		ForceCGA:           false,
-		WinnerFirst:        false,
-		VariableWind:       false,
-		WindFluctuations:   false,
+		UseSound:            true,
+		UseVectorExplosions: false,
+		NewExplosionRadius:  40,
+		UseSlidingText:      false,
+		DefaultGravity:      17,
+		DefaultRoundQty:     4,
+		ShowIntro:           true,
+		ForceCGA:            false,
+		WinnerFirst:         false,
+		VariableWind:        false,
+		WindFluctuations:    false,
 	}
 }
 
@@ -257,6 +260,16 @@ func (g *Game) startGorillaExplosion(idx int) {
 			color.RGBA{255, 255, 0, 255},
 			color.RGBA{255, 255, 255, 255},
 			color.Black,
+		}
+		if g.Settings.UseVectorExplosions {
+			frames := []float64{base, base * 0.9, base * 0.6, base * 0.45}
+			for _, r := range frames {
+				w := 2 * r
+				h := 2 * r * 0.825
+				offX := g.Explosion.X - r
+				offY := g.Explosion.Y - r*0.825
+				g.Explosion.Vectors = append(g.Explosion.Vectors, scaleVector(vectorData, w, h, offX, offY))
+			}
 		}
 	}
 	g.Explosion.Active = true

--- a/vector_explosion.go
+++ b/vector_explosion.go
@@ -1,0 +1,33 @@
+package gorillas
+
+// VectorPoint represents a relative coordinate in a vector shape.
+type VectorPoint struct {
+	X, Y float64
+}
+
+// vectorData holds the points used by the original BASIC vector explosion.
+var vectorData = []VectorPoint{
+	{0.582, 0.988}, {0.608, 0.850}, {0.663, 0.788}, {0.738, 0.800},
+	{0.863, 0.838}, {0.813, 0.713}, {0.819, 0.650}, {0.875, 0.588},
+	{1.000, 0.563}, {0.850, 0.450}, {0.825, 0.400}, {0.830, 0.340},
+	{0.925, 0.238}, {0.775, 0.243}, {0.694, 0.225}, {0.650, 0.188}, {0.630, 0.105},
+	{0.625, 0.025}, {0.535, 0.150}, {0.475, 0.175}, {0.425, 0.150},
+	{0.325, 0.044}, {0.325, 0.150}, {0.315, 0.208}, {0.288, 0.250}, {0.225, 0.275},
+	{0.053, 0.288}, {0.150, 0.392}, {0.175, 0.463}, {0.144, 0.525},
+	{0.025, 0.638}, {0.163, 0.650}, {0.225, 0.693}, {0.250, 0.775},
+	{0.225, 0.905}, {0.360, 0.825}, {0.450, 0.823}, {0.525, 0.863},
+	{0.582, 0.988},
+}
+
+// scaleVector returns the given data scaled to width and height and translated
+// by offset.
+func scaleVector(data []VectorPoint, width, height, offX, offY float64) []VectorPoint {
+	pts := make([]VectorPoint, len(data))
+	for i, p := range data {
+		pts[i] = VectorPoint{
+			X: offX + p.X*width,
+			Y: offY + p.Y*height,
+		}
+	}
+	return pts
+}


### PR DESCRIPTION
## Summary
- port BASIC vector explosion data to Go
- add `UseVectorExplosions` setting
- precompute vector lines in `startGorillaExplosion`
- render vector lines for explosions in Ebiten and tcell
- test configuration loading of the new setting

## Testing
- `go test ./...` *(fails: missing system deps)*

------
https://chatgpt.com/codex/tasks/task_e_685ce56ee3a0832f8296e2cdf6d69f31