### PR TITLE
Add instructions screen

### DIFF
--- a/cmd/gorillia-ebiten/instructions_state.go
+++ b/cmd/gorillia-ebiten/instructions_state.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"image/color"
+	"time"
+
+	"github.com/arran4/gorillas"
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+)
+
+// instructionsState displays credits and instructions.
+type instructionsState struct {
+	lines   []string
+	sliding bool
+	charIdx int
+	maxLen  int
+	next    time.Time
+	done    bool
+}
+
+func newInstructionsState(sliding bool) *instructionsState {
+	lines, err := gorillas.LoadInstructions()
+	if err != nil {
+		lines = []string{"Instructions unavailable"}
+	}
+	maxLen := 0
+	for _, l := range lines {
+		if len(l) > maxLen {
+			maxLen = len(l)
+		}
+	}
+	return &instructionsState{lines: lines, sliding: sliding, maxLen: maxLen, next: time.Now()}
+}
+
+func (s *instructionsState) Update(g *Game) error {
+	if s.done {
+		if len(inpututil.AppendJustPressedKeys(nil)) > 0 {
+			g.State = newMenuState(g.Settings.UseSound, g.Settings.UseSlidingText)
+		}
+		return nil
+	}
+	if !s.sliding {
+		s.charIdx = s.maxLen
+		s.done = true
+		return nil
+	}
+	if time.Now().After(s.next) {
+		s.charIdx++
+		s.next = time.Now().Add(30 * time.Millisecond)
+		if s.charIdx > s.maxLen {
+			s.charIdx = s.maxLen
+			s.done = true
+		}
+	}
+	return nil
+}
+
+func (s *instructionsState) Draw(g *Game, screen *ebiten.Image) {
+	screen.Fill(color.RGBA{0, 0, 0, 255})
+	y0 := g.Height/2 - len(s.lines)*charH/2
+	for i, line := range s.lines {
+		draw := line
+		if s.sliding && s.charIdx < len(line) {
+			if s.charIdx <= 0 {
+				draw = ""
+			} else {
+				draw = line[:s.charIdx]
+			}
+		}
+		ebitenutil.DebugPrintAt(screen, draw, (g.Width-len(line)*charW)/2, y0+i*charH)
+	}
+}

--- a/cmd/gorillia-ebiten/menu_state.go
+++ b/cmd/gorillia-ebiten/menu_state.go
@@ -45,6 +45,9 @@ func (m *menuState) Update(g *Game) error {
 			case ebiten.KeyV:
 				g.State = newIntroMovieState(m.useSound, m.sliding)
 				return nil
+			case ebiten.KeyI:
+				g.State = newInstructionsState(m.sliding)
+				return nil
 			}
 		}
 	}
@@ -73,9 +76,11 @@ func (m *menuState) Draw(g *Game, screen *ebiten.Image) {
 	if m.stage == 1 {
 		line := "V - View Intro"
 		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+3*charH)
-		line = "P - Play Game"
+		line = "I - Instructions"
 		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+4*charH)
-		line = "Q - Quit"
+		line = "P - Play Game"
 		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+5*charH)
+		line = "Q - Quit"
+		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+6*charH)
 	}
 }

--- a/cmd/gorillia-tcell/intro.go
+++ b/cmd/gorillia-tcell/intro.go
@@ -95,6 +95,40 @@ func showIntroMovie(s tcell.Screen, useSound, sliding bool) {
 	SparklePause(s, 0)
 }
 
+func showInstructions(s tcell.Screen, sliding bool) {
+	lines, err := gorillas.LoadInstructions()
+	if err != nil {
+		lines = []string{"Instructions unavailable"}
+	}
+	w, h := s.Size()
+	maxLen := 0
+	for _, l := range lines {
+		if len(l) > maxLen {
+			maxLen = len(l)
+		}
+	}
+	y := h/2 - len(lines)/2
+	if sliding {
+		for i := 1; i <= maxLen; i++ {
+			for j, line := range lines {
+				n := i
+				if n > len(line) {
+					n = len(line)
+				}
+				drawString(s, (w-len(line))/2, y+j, line[:n])
+			}
+			s.Show()
+			time.Sleep(30 * time.Millisecond)
+		}
+	} else {
+		for j, line := range lines {
+			drawString(s, (w-len(line))/2, y+j, line)
+		}
+		s.Show()
+	}
+	SparklePause(s, 0)
+}
+
 func introScreen(s tcell.Screen, useSound, sliding bool) bool {
 	w, h := s.Size()
 	cx := w/2 - 10
@@ -113,8 +147,9 @@ func introScreen(s tcell.Screen, useSound, sliding bool) bool {
 		drawGorillaFrame(s, cx+12, cy, gorillaFrames[0])
 		drawString(s, w/2-4, cy-2, "GORILLAS")
 		drawString(s, w/2-9, cy+3, "V - View Intro")
-		drawString(s, w/2-9, cy+4, "P - Play Game")
-		drawString(s, w/2-9, cy+5, "Q - Quit")
+		drawString(s, w/2-9, cy+4, "I - Instructions")
+		drawString(s, w/2-9, cy+5, "P - Play Game")
+		drawString(s, w/2-9, cy+6, "Q - Quit")
 		s.Show()
 		ev := s.PollEvent()
 		if key, ok := ev.(*tcell.EventKey); ok {
@@ -125,6 +160,8 @@ func introScreen(s tcell.Screen, useSound, sliding bool) bool {
 				return true
 			case 'v', 'V':
 				showIntroMovie(s, useSound, sliding)
+			case 'i', 'I':
+				showInstructions(s, sliding)
 			}
 		}
 	}

--- a/instructions.go
+++ b/instructions.go
@@ -1,0 +1,42 @@
+package gorillas
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// LoadInstructions parses the SlidyText section from gorillas.bas and
+// returns the credit and instruction lines.
+func LoadInstructions() ([]string, error) {
+	f, err := os.Open("gorillas.bas")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	var lines []string
+	found := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !found {
+			if strings.HasPrefix(line, "SlidyText:") {
+				found = true
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "PartingMessage:") {
+			break
+		}
+		if strings.HasPrefix(line, "DATA") {
+			fields := strings.SplitN(strings.TrimSpace(line[4:]), ",", 2)
+			if len(fields) > 0 {
+				token := strings.TrimSpace(fields[0])
+				if strings.HasPrefix(token, "\"") && strings.HasSuffix(token, "\"") {
+					lines = append(lines, strings.Trim(token, "\""))
+				}
+			}
+		}
+	}
+	return lines, scanner.Err()
+}


### PR DESCRIPTION
## Summary
- expose BASIC instructions by parsing gorillas.bas
- implement instructionsState for Ebiten
- add key/option in menu to view instructions
- implement showInstructions for tcell
- wire instructions option into tcell menu

## Testing
- `go test ./...` *(fails: X11/alsa dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ce565a438832fa6ecd8459ece8f06