### PR TITLE
Add AI option for ebiten version

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -149,7 +149,7 @@ type building struct {
 
 type Game struct {
 	*gorillas.Game
-	gamepads    []ebiten.GamepadID
+	gamepads     []ebiten.GamepadID
 	buildings    []building
 	sunX, sunY   float64
 	sunHitTicks  int
@@ -167,6 +167,7 @@ type Game struct {
 	bananaDown   *ebiten.Image
 	gorillaImg   *ebiten.Image
 	gorillaArt   [][]string
+	AI           bool
 	State        State
 }
 
@@ -287,12 +288,14 @@ func main() {
 	buildings := flag.Int("buildings", gorillas.DefaultBuildingCount, "building count")
 	p1 := flag.String("player1", "Player 1", "name of player 1")
 	p2 := flag.String("player2", "Player 2", "name of player 2")
+	ai := flag.Bool("ai", false, "enable computer opponent")
 	flag.BoolVar(&settings.UseSound, "sound", settings.UseSound, "enable sound")
 	flag.BoolVar(&settings.WinnerFirst, "winnerfirst", settings.WinnerFirst, "winner starts next round")
 	flag.Parse()
 	settings.DefaultGravity = *gravity
 	settings.DefaultRoundQty = *rounds
 	game := newGame(settings, *buildings, *wind)
+	game.AI = *ai
 	game.Players = [2]string{*p1, *p2}
 	if settings.ShowIntro {
 		game.State = newIntroMovieState(settings.UseSound, settings.UseSlidingText)

--- a/cmd/gorillia-ebiten/play_state.go
+++ b/cmd/gorillia-ebiten/play_state.go
@@ -40,6 +40,10 @@ func (playState) Update(g *Game) error {
 		return nil
 	}
 	if !g.Banana.Active && !g.Explosion.Active {
+		if g.AI && g.Current == 1 {
+			g.Game.AutoShot()
+			return nil
+		}
 		if g.enteringAng || g.enteringPow {
 			for _, r := range ebiten.AppendInputChars(nil) {
 				if r == '*' {


### PR DESCRIPTION
## Summary
- add AI mode to Ebiten game via `-ai` flag
- automatically fire shot when player 2 is AI-controlled

## Testing
- `go test ./...` *(fails: missing system libraries)*

------
https://chatgpt.com/codex/tasks/task_e_685ceb754b7c832f82827c463059f4bd