### PR TITLE
Document CGA palette option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ command-line flags:
   -winnerfirst winner of a round starts next
 ```
 
+### Configuration
+
+Certain options can also be toggled through environment variables. Set
+`GORILLAS_FORCE_CGA=true` to restrict both frontends to the classic CGA
+palette (black, cyan, magenta, white). This can be handy on limited
+terminals or for nostalgia.
+
 ### Building and Running
 
 #### Prerequisites


### PR DESCRIPTION
## Summary
- add a Configuration section to the README
- explain the `GORILLAS_FORCE_CGA` env var

## Testing
- `go test ./...` *(fails: missing system packages)*
- `go test -tags test ./...` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ceb8e49dc832fa4bbc4ed91f78c2f