### PR TITLE
Unify hotseat control scheme

### DIFF
--- a/cmd/gorillia-ebiten/instructions_state.go
+++ b/cmd/gorillia-ebiten/instructions_state.go
@@ -1,3 +1,5 @@
+//go:build !test
+
 package main
 
 import (

--- a/cmd/gorillia-ebiten/menu_state.go
+++ b/cmd/gorillia-ebiten/menu_state.go
@@ -78,17 +78,11 @@ func (m *menuState) Draw(g *Game, screen *ebiten.Image) {
 	if m.stage == 1 {
 		line := "V/X - View Intro"
 		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+3*charH)
-<<<<<<< codex/add-instructionsstate-for-ebiten-and-tcell-ports
 		line = "I - Instructions"
 		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+4*charH)
-		line = "P - Play Game"
-=======
 		line = "P/Start - Play Game"
-		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+4*charH)
-		line = "Q/B - Quit"
->>>>>>> master
 		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+5*charH)
-		line = "Q - Quit"
+		line = "Q/B - Quit"
 		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+6*charH)
 	}
 }

--- a/cmd/gorillia-ebiten/play_state.go
+++ b/cmd/gorillia-ebiten/play_state.go
@@ -140,38 +140,20 @@ func (playState) Update(g *Game) error {
 				return nil
 			}
 		}
-		if g.Current == 0 {
-			if ebiten.IsKeyPressed(ebiten.KeyLeft) {
-				g.Angle += 1
-			}
-			if ebiten.IsKeyPressed(ebiten.KeyRight) {
-				g.Angle -= 1
-			}
-			if ebiten.IsKeyPressed(ebiten.KeyUp) {
-				g.Power += 1
-			}
-			if ebiten.IsKeyPressed(ebiten.KeyDown) {
-				g.Power -= 1
-			}
-			if ebiten.IsKeyPressed(ebiten.KeySpace) {
-				g.Throw()
-			}
-		} else {
-			if ebiten.IsKeyPressed(ebiten.KeyA) {
-				g.Angle += 1
-			}
-			if ebiten.IsKeyPressed(ebiten.KeyD) {
-				g.Angle -= 1
-			}
-			if ebiten.IsKeyPressed(ebiten.KeyW) {
-				g.Power += 1
-			}
-			if ebiten.IsKeyPressed(ebiten.KeyS) {
-				g.Power -= 1
-			}
-			if ebiten.IsKeyPressed(ebiten.KeyF) {
-				g.Throw()
-			}
+		if ebiten.IsKeyPressed(ebiten.KeyLeft) {
+			g.Angle += 1
+		}
+		if ebiten.IsKeyPressed(ebiten.KeyRight) {
+			g.Angle -= 1
+		}
+		if ebiten.IsKeyPressed(ebiten.KeyUp) {
+			g.Power += 1
+		}
+		if ebiten.IsKeyPressed(ebiten.KeyDown) {
+			g.Power -= 1
+		}
+		if ebiten.IsKeyPressed(ebiten.KeySpace) {
+			g.Throw()
 		}
 
 		g.gamepads = ebiten.AppendGamepadIDs(g.gamepads[:0])

--- a/cmd/gorillia-tcell/intro.go
+++ b/cmd/gorillia-tcell/intro.go
@@ -146,16 +146,10 @@ func introScreen(s tcell.Screen, useSound, sliding bool) bool {
 		drawGorillaFrame(s, cx, cy, gorillaFrames[0])
 		drawGorillaFrame(s, cx+12, cy, gorillaFrames[0])
 		drawString(s, w/2-4, cy-2, "GORILLAS")
-<<<<<<< codex/add-instructionsstate-for-ebiten-and-tcell-ports
-		drawString(s, w/2-9, cy+3, "V - View Intro")
-		drawString(s, w/2-9, cy+4, "I - Instructions")
-		drawString(s, w/2-9, cy+5, "P - Play Game")
-		drawString(s, w/2-9, cy+6, "Q - Quit")
-=======
 		drawString(s, w/2-9, cy+3, "V/X - View Intro")
-		drawString(s, w/2-9, cy+4, "P/Start - Play Game")
-		drawString(s, w/2-9, cy+5, "Q/B - Quit")
->>>>>>> master
+		drawString(s, w/2-9, cy+4, "I - Instructions")
+		drawString(s, w/2-9, cy+5, "P/Start - Play Game")
+		drawString(s, w/2-9, cy+6, "Q/B - Quit")
 		s.Show()
 		ev := s.PollEvent()
 		if key, ok := ev.(*tcell.EventKey); ok {

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -23,19 +23,20 @@ type building struct {
 
 type Game struct {
 	*gorillas.Game
-	buildings   []building
-	screen      tcell.Screen
-	sunX, sunY  int
-	sunHitTicks int
-	angleInput  string
-	powerInput  string
-	enteringAng bool
-	enteringPow bool
-	abortPrompt bool
-	resumeAng   bool
-	resumePow   bool
-	gorillaArt  [][]string
-	js          *joystick
+	buildings    []building
+	screen       tcell.Screen
+	sunX, sunY   int
+	sunHitTicks  int
+	sunIntegrity int
+	angleInput   string
+	powerInput   string
+	enteringAng  bool
+	enteringPow  bool
+	abortPrompt  bool
+	resumeAng    bool
+	resumePow    bool
+	gorillaArt   [][]string
+	js           *joystick
 }
 
 const buildingWidth = 8


### PR DESCRIPTION
## Summary
- resolve leftover merge conflicts in intro/menu screens
- add missing build tag for instructions_state
- include sunIntegrity in tcell Game struct
- apply same keyboard controls for both players in Ebiten port

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cebc2936c832fa15f584067269683