### PR TITLE
Add explosion building damage

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -141,15 +141,18 @@ func defaultGorillaSprite() *ebiten.Image {
 	return createGorillaSprite(mask, color.RGBA{150, 75, 0, 255})
 }
 
+type damageRect struct{ x, y, w, h float64 }
+
 type building struct {
 	x, w, h float64
 	color   color.Color
 	windows []window
+	damage  []damageRect
 }
 
 type Game struct {
 	*gorillas.Game
-	gamepads    []ebiten.GamepadID
+	gamepads     []ebiten.GamepadID
 	buildings    []building
 	sunX, sunY   float64
 	sunHitTicks  int

--- a/cmd/gorillia-ebiten/play_state.go
+++ b/cmd/gorillia-ebiten/play_state.go
@@ -222,11 +222,23 @@ func (playState) Draw(g *Game, screen *ebiten.Image) {
 	screen.Fill(color.RGBA{0, 0, 0, 255})
 	for i := range g.buildings {
 		g.buildings[i].h = g.Buildings[i].H
+		g.buildings[i].damage = g.buildings[i].damage[:0]
+		for _, d := range g.Buildings[i].Damage {
+			g.buildings[i].damage = append(g.buildings[i].damage, damageRect{
+				x: d.X,
+				y: d.Y,
+				w: d.W,
+				h: d.H,
+			})
+		}
 	}
 	for i, b := range g.buildings {
 		ebitenutil.DrawRect(screen, b.x, float64(g.Height)-b.h, b.w-1, b.h, b.color)
 		for _, w := range b.windows {
 			ebitenutil.DrawRect(screen, w.x, w.y, w.w, w.h, color.RGBA{255, 255, 0, 255})
+		}
+		for _, d := range b.damage {
+			ebitenutil.DrawRect(screen, d.x, d.y, d.w, d.h, color.Black)
 		}
 		_ = i
 	}

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -16,9 +16,12 @@ import (
 	"github.com/gdamore/tcell/v2"
 )
 
+type damageRect struct{ x, y, w, h int }
+
 type building struct {
 	h       int
 	windows []int
+	damage  []damageRect
 }
 
 type Game struct {
@@ -164,6 +167,15 @@ func (g *Game) draw() {
 	g.screen.Clear()
 	for i := range g.buildings {
 		g.buildings[i].h = int(g.Buildings[i].H)
+		g.buildings[i].damage = g.buildings[i].damage[:0]
+		for _, d := range g.Buildings[i].Damage {
+			g.buildings[i].damage = append(g.buildings[i].damage, damageRect{
+				x: int(d.X),
+				y: int(d.Y),
+				w: int(d.W),
+				h: int(d.H),
+			})
+		}
 	}
 	for i, b := range g.buildings {
 		x := i*buildingWidth + 4
@@ -172,6 +184,13 @@ func (g *Game) draw() {
 		}
 		for _, wy := range b.windows {
 			g.screen.SetContent(x, wy, 'o', nil, tcell.StyleDefault)
+		}
+		for _, d := range b.damage {
+			for dx := 0; dx < d.w; dx++ {
+				for dy := 0; dy < d.h; dy++ {
+					g.screen.SetContent(d.x+dx, d.y+dy, ' ', nil, tcell.StyleDefault)
+				}
+			}
 		}
 	}
 	g.drawGorilla(0)


### PR DESCRIPTION
## Summary
- store damage rectangles inside Building when explosions happen
- copy damage rectangles into frontend data for both Ebiten and tcell
- clip out damaged areas when drawing buildings

## Testing
- `go test ./...` *(fails: missing X11 and ALSA)*

------
https://chatgpt.com/codex/tasks/task_e_685ceb58d8b0832f80b30e452e01a0d9