### PR TITLE
Add gorilla throw animation frames

### DIFF
--- a/cmd/gorillia-ebiten/constants.go
+++ b/cmd/gorillia-ebiten/constants.go
@@ -7,6 +7,12 @@ const (
 	charH = 16
 )
 
+const (
+	frameArmsDown = iota
+	frameRightUp
+	frameLeftUp
+)
+
 // gorillaFrames represents the ASCII gorilla animation frames shared by
 // the intro movie and menu state.
 var gorillaFrames = [][]string{

--- a/cmd/gorillia-ebiten/play_state.go
+++ b/cmd/gorillia-ebiten/play_state.go
@@ -17,7 +17,19 @@ import (
 // playState implements the main gameplay loop.
 type playState struct{}
 
+func (g *Game) throw() {
+	if g.Current == 0 {
+		g.gorillaFrame[0] = frameRightUp
+	} else {
+		g.gorillaFrame[1] = frameLeftUp
+	}
+	g.thrower = g.Current
+	g.throwTicks = 2
+	g.Throw()
+}
+
 func (playState) Update(g *Game) error {
+	g.updateThrowFrame()
 	if g.abortPrompt {
 		for _, k := range inpututil.AppendJustPressedKeys(nil) {
 			switch k {
@@ -88,7 +100,7 @@ func (playState) Update(g *Game) error {
 						}
 						g.enteringPow = false
 						g.powerInput = ""
-						g.Throw()
+						g.throw()
 					}
 				case ebiten.KeyEscape:
 					if g.enteringAng || g.enteringPow {
@@ -154,7 +166,7 @@ func (playState) Update(g *Game) error {
 				g.Power -= 1
 			}
 			if ebiten.IsKeyPressed(ebiten.KeySpace) {
-				g.Throw()
+				g.throw()
 			}
 		} else {
 			if ebiten.IsKeyPressed(ebiten.KeyA) {
@@ -170,7 +182,7 @@ func (playState) Update(g *Game) error {
 				g.Power -= 1
 			}
 			if ebiten.IsKeyPressed(ebiten.KeyF) {
-				g.Throw()
+				g.throw()
 			}
 		}
 
@@ -191,11 +203,11 @@ func (playState) Update(g *Game) error {
 					g.Power -= 1
 				}
 				if inpututil.IsStandardGamepadButtonJustPressed(id, ebiten.StandardGamepadButtonRightBottom) {
-					g.Throw()
+					g.throw()
 				}
 			} else {
 				if inpututil.IsGamepadButtonJustPressed(id, ebiten.GamepadButton0) {
-					g.Throw()
+					g.throw()
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- add frame constants for LEFTUP, RIGHTUP and ARMSDOWN
- generate gorilla sprites for each frame
- track per-gorilla frame state and animate on throw
- implement same behaviour in tcell backend

## Testing
- `go test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ceb78f8e0832fb14bd1e0a30910a7