### PR TITLE
Add shot logging and replay feature

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -149,7 +149,7 @@ type building struct {
 
 type Game struct {
 	*gorillas.Game
-	gamepads    []ebiten.GamepadID
+	gamepads     []ebiten.GamepadID
 	buildings    []building
 	sunX, sunY   float64
 	sunHitTicks  int
@@ -183,6 +183,7 @@ func newGame(settings gorillas.Settings, buildings int, wind float64) *Game {
 	}
 	g.gorillaImg = defaultGorillaSprite()
 	g.LoadScores()
+	g.LoadShots()
 	rand.Seed(time.Now().UnixNano())
 	bw := float64(g.Width) / float64(g.Game.BuildingCount)
 	for i := 0; i < g.Game.BuildingCount; i++ {

--- a/cmd/gorillia-ebiten/menu_state.go
+++ b/cmd/gorillia-ebiten/menu_state.go
@@ -50,6 +50,9 @@ func (m *menuState) Update(g *Game) error {
 			case ebiten.KeyI:
 				g.State = newInstructionsState(m.sliding)
 				return nil
+			case ebiten.KeyR:
+				g.State = newReplayState(g)
+				return nil
 			}
 		}
 	}
@@ -78,17 +81,13 @@ func (m *menuState) Draw(g *Game, screen *ebiten.Image) {
 	if m.stage == 1 {
 		line := "V/X - View Intro"
 		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+3*charH)
-<<<<<<< codex/add-instructionsstate-for-ebiten-and-tcell-ports
 		line = "I - Instructions"
 		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+4*charH)
 		line = "P - Play Game"
-=======
-		line = "P/Start - Play Game"
-		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+4*charH)
-		line = "Q/B - Quit"
->>>>>>> master
 		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+5*charH)
-		line = "Q - Quit"
+		line = "R - Replays"
 		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+6*charH)
+		line = "Q - Quit"
+		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, cy+7*charH)
 	}
 }

--- a/cmd/gorillia-ebiten/replay_state.go
+++ b/cmd/gorillia-ebiten/replay_state.go
@@ -1,0 +1,78 @@
+//go:build !test
+
+package main
+
+import (
+	"fmt"
+	"image/color"
+	"time"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+)
+
+type replayState struct {
+	lines []string
+	start time.Time
+	phase int
+	next  time.Time
+}
+
+func newReplayState(g *Game) *replayState {
+	lines := []string{"Stored Shots:"}
+	for i, sh := range g.ShotHistory {
+		orig := g.Wind
+		g.Wind = sh.Wind
+		res := g.testShot(sh.Angle, sh.Power)
+		g.Wind = orig
+		lines = append(lines, fmt.Sprintf("%2d: %.0f %.0f wind %.1f -> %v", i+1, sh.Angle, sh.Power, sh.Wind, res))
+	}
+	if len(lines) == 1 {
+		lines = append(lines, "No shots recorded")
+	}
+	lines = append(lines, "", "Press any key to continue")
+	return &replayState{lines: lines}
+}
+
+func (s *replayState) Update(g *Game) error {
+	if s.start.IsZero() {
+		s.start = time.Now()
+		s.next = s.start.Add(50 * time.Millisecond)
+		return nil
+	}
+	if len(inpututil.AppendJustPressedKeys(nil)) > 0 {
+		g.State = newMenuState(g.Settings.UseSound, g.Settings.UseSlidingText)
+		return nil
+	}
+	if time.Now().After(s.next) {
+		s.phase = (s.phase + 1) % 5
+		s.next = time.Now().Add(50 * time.Millisecond)
+	}
+	return nil
+}
+
+func (s *replayState) Draw(g *Game, screen *ebiten.Image) {
+	screen.Fill(color.RGBA{0, 0, 0, 255})
+	pattern := []rune("*    ")
+	cols := g.Width / charW
+	rows := g.Height / charH
+	for x := 0; x < cols; x++ {
+		ch1 := pattern[(s.phase+x)%5]
+		ch2 := pattern[(4-s.phase+x)%5]
+		ebitenutil.DebugPrintAt(screen, string(ch1), x*charW, 0)
+		ebitenutil.DebugPrintAt(screen, string(ch2), x*charW, (rows-1)*charH)
+	}
+	for y := 1; y < rows-1; y++ {
+		ch := ' '
+		if (s.phase+y)%5 == 0 {
+			ch = '*'
+		}
+		ebitenutil.DebugPrintAt(screen, string(ch), (cols-1)*charW, y*charH)
+		ebitenutil.DebugPrintAt(screen, string(ch), 0, (rows-1-y)*charH)
+	}
+	y0 := rows/2 - len(s.lines)/2
+	for i, line := range s.lines {
+		ebitenutil.DebugPrintAt(screen, line, (g.Width-len(line)*charW)/2, (y0+i)*charH)
+	}
+}

--- a/cmd/gorillia-tcell/intro.go
+++ b/cmd/gorillia-tcell/intro.go
@@ -149,12 +149,14 @@ func introScreen(s tcell.Screen, useSound, sliding bool) bool {
 <<<<<<< codex/add-instructionsstate-for-ebiten-and-tcell-ports
 		drawString(s, w/2-9, cy+3, "V - View Intro")
 		drawString(s, w/2-9, cy+4, "I - Instructions")
-		drawString(s, w/2-9, cy+5, "P - Play Game")
-		drawString(s, w/2-9, cy+6, "Q - Quit")
+               drawString(s, w/2-9, cy+5, "P - Play Game")
+               drawString(s, w/2-9, cy+6, "R - Replays")
+               drawString(s, w/2-9, cy+7, "Q - Quit")
 =======
 		drawString(s, w/2-9, cy+3, "V/X - View Intro")
-		drawString(s, w/2-9, cy+4, "P/Start - Play Game")
-		drawString(s, w/2-9, cy+5, "Q/B - Quit")
+               drawString(s, w/2-9, cy+4, "P/Start - Play Game")
+               drawString(s, w/2-9, cy+5, "R - Replays")
+               drawString(s, w/2-9, cy+6, "Q/B - Quit")
 >>>>>>> master
 		s.Show()
 		ev := s.PollEvent()
@@ -164,11 +166,15 @@ func introScreen(s tcell.Screen, useSound, sliding bool) bool {
 				return false
 			case 'p', 'P':
 				return true
-			case 'v', 'V':
-				showIntroMovie(s, useSound, sliding)
-			case 'i', 'I':
-				showInstructions(s, sliding)
-			}
+                       case 'v', 'V':
+                               showIntroMovie(s, useSound, sliding)
+                       case 'i', 'I':
+                               showInstructions(s, sliding)
+                       case 'r', 'R':
+                               rg := gorillas.NewGame(80, 24, gorillas.DefaultBuildingCount)
+                               rg.LoadShots()
+                               showReplays(s, rg)
+                       }
 		}
 	}
 }
@@ -244,5 +250,29 @@ func showLeague(s tcell.Screen, l *gorillas.League) {
 	msg := "Press any key to continue"
 	drawString(s, (w-len(msg))/2, y+len(rows)+1, msg)
 	s.Show()
-	SparklePause(s, 0)
+       SparklePause(s, 0)
+}
+
+func showReplays(s tcell.Screen, g *gorillas.Game) {
+       rows := []string{"Stored Shots:"}
+       for i, sh := range g.ShotHistory {
+               orig := g.Wind
+               g.Wind = sh.Wind
+               res := g.testShot(sh.Angle, sh.Power)
+               g.Wind = orig
+               rows = append(rows, fmt.Sprintf("%2d: %.0f %.0f wind %.1f -> %v", i+1, sh.Angle, sh.Power, sh.Wind, res))
+       }
+       if len(rows) == 1 {
+               rows = append(rows, "No shots recorded")
+       }
+       s.Clear()
+       w, h := s.Size()
+       y := h/2 - len(rows)/2
+       for i, line := range rows {
+               drawString(s, (w-len(line))/2, y+i, line)
+       }
+       msg := "Press any key to continue"
+       drawString(s, (w-len(msg))/2, y+len(rows)+1, msg)
+       s.Show()
+       SparklePause(s, 0)
 }

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -95,6 +95,7 @@ func newGame(settings gorillas.Settings, buildings int, wind float64) *Game {
 		g.gorillaArt = [][]string{{" O ", "/|\\", "/ \\"}}
 	}
 	g.LoadScores()
+	g.LoadShots()
 	rand.Seed(time.Now().UnixNano())
 	for _, b := range g.Buildings {
 		var wins []int


### PR DESCRIPTION
## Summary
- track successful throws in a new `Shot` structure
- save and load shot history from `gorillas_shots.json`
- show a replay list from the main menu in both ports
- implement ebiten `replayState` to render replays

## Testing
- `go test ./...` *(fails: missing system deps)*

------
https://chatgpt.com/codex/tasks/task_e_685ceb6d4768832fb6e1c17847785007