### PR TITLE
Add tests for shot history persistence

### DIFF
--- a/game.go
+++ b/game.go
@@ -89,6 +89,12 @@ type Dance struct {
 	Active bool
 }
 
+// ShotRecord stores the angle and power for a single throw.
+type ShotRecord struct {
+	Angle float64 `json:"angle"`
+	Power float64 `json:"power"`
+}
+
 func DefaultSettings() Settings {
 	return Settings{
 		UseSound:            true,
@@ -133,6 +139,34 @@ func (g *Game) SaveScores() {
 	}
 }
 
+// LoadShots reads the shot history from disk.
+func (g *Game) LoadShots() {
+	file := g.ShotsFile
+	if file == "" {
+		file = defaultShotsFile
+	}
+	b, err := os.ReadFile(file)
+	if err == nil {
+		if err := json.Unmarshal(b, &g.ShotHistory); err != nil {
+			fmt.Fprintf(os.Stderr, "load shots: %v\n", err)
+		}
+	}
+}
+
+// SaveShots writes the shot history to disk.
+func (g *Game) SaveShots() {
+	file := g.ShotsFile
+	if file == "" {
+		file = defaultShotsFile
+	}
+	b, err := json.Marshal(g.ShotHistory)
+	if err == nil {
+		if err := os.WriteFile(file, b, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "save shots: %v\n", err)
+		}
+	}
+}
+
 // StatsString returns a printable summary of wins this session and overall.
 func (g *Game) StatsString() string {
 	session := fmt.Sprintf("Session - P1:%d P2:%d", g.Wins[0], g.Wins[1])
@@ -162,6 +196,8 @@ type Game struct {
 	Players       [2]string
 	League        *League
 	ScoreFile     string
+	ShotsFile     string
+	ShotHistory   []ShotRecord
 	Wind          float64
 	BuildingCount int
 	Gravity       float64
@@ -181,6 +217,7 @@ type Game struct {
 const DefaultBuildingCount = 10
 const defaultScoreFile = "gorillas_scores.json"
 const defaultLeagueFile = "gorillas.lge"
+const defaultShotsFile = "gorillas_shots.json"
 const groundBounceFactor = 0.4
 const groundBounceThreshold = 5.0
 
@@ -188,7 +225,7 @@ func NewGame(width, height, buildingCount int) *Game {
 	if buildingCount <= 0 {
 		buildingCount = DefaultBuildingCount
 	}
-	g := &Game{Width: width, Height: height, Angle: 45, Power: 50, ScoreFile: defaultScoreFile, BuildingCount: buildingCount, Aborted: false}
+	g := &Game{Width: width, Height: height, Angle: 45, Power: 50, ScoreFile: defaultScoreFile, ShotsFile: defaultShotsFile, BuildingCount: buildingCount, Aborted: false}
 	g.League = LoadLeague(defaultLeagueFile)
 	g.Players = [2]string{"Player 1", "Player 2"}
 	g.Settings = DefaultSettings()
@@ -248,6 +285,7 @@ func (g *Game) Reset() {
 	wins := g.Wins
 	totals := g.TotalWins
 	file := g.ScoreFile
+	shotsFile := g.ShotsFile
 	players := g.Players
 	league := g.League
 	settings := g.Settings
@@ -256,6 +294,7 @@ func (g *Game) Reset() {
 	g.Wins = wins
 	g.TotalWins = totals
 	g.ScoreFile = file
+	g.ShotsFile = shotsFile
 	g.Players = players
 	g.League = league
 	g.Settings = settings

--- a/game_test.go
+++ b/game_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"math/rand"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -275,6 +276,22 @@ func TestSaveAndLoadScores(t *testing.T) {
 
 	if g2.TotalWins != g1.TotalWins {
 		t.Fatalf("expected %v, got %v", g1.TotalWins, g2.TotalWins)
+	}
+}
+
+func TestSaveAndLoadShots(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "shots.json")
+	g1 := newTestGame()
+	g1.ShotsFile = tmp
+	g1.ShotHistory = []ShotRecord{{Angle: 45, Power: 50}, {Angle: 30, Power: 60}}
+	g1.SaveShots()
+
+	g2 := newTestGame()
+	g2.ShotsFile = tmp
+	g2.LoadShots()
+
+	if !reflect.DeepEqual(g2.ShotHistory, g1.ShotHistory) {
+		t.Fatalf("expected %v, got %v", g1.ShotHistory, g2.ShotHistory)
 	}
 }
 


### PR DESCRIPTION
## Summary
- implement `ShotRecord` and shot history persistence
- add new game fields and default file constant
- include tests verifying SaveShots and LoadShots

## Testing
- `go test -tags test`

------
https://chatgpt.com/codex/tasks/task_e_685cf45f0498832f9ca61b1155934332