### PR TITLE
Fix tcell intro menu

### DIFF
--- a/cmd/gorillia-tcell/intro.go
+++ b/cmd/gorillia-tcell/intro.go
@@ -149,7 +149,8 @@ func introScreen(s tcell.Screen, useSound, sliding bool) bool {
 		drawString(s, w/2-9, cy+3, "V/X - View Intro")
 		drawString(s, w/2-9, cy+4, "I - Instructions")
 		drawString(s, w/2-9, cy+5, "P/Start - Play Game")
-		drawString(s, w/2-9, cy+6, "Q/B - Quit")
+		drawString(s, w/2-9, cy+6, "R - Replays")
+		drawString(s, w/2-9, cy+7, "Q/B - Quit")
 		s.Show()
 		ev := s.PollEvent()
 		if key, ok := ev.(*tcell.EventKey); ok {


### PR DESCRIPTION
## Summary
- update the intro menu so all options appear

## Testing
- `gofmt -w cmd/gorillia-tcell/intro.go`
- `go build ./...` *(fails: `Package 'alsa', required by 'virtual:world', not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685cf45b43f0832fb0f5199c838d251c