### PR TITLE
Fix gamepad compile errors

### DIFF
--- a/cmd/gorillia-ebiten/play_state.go
+++ b/cmd/gorillia-ebiten/play_state.go
@@ -3,15 +3,17 @@
 package main
 
 import (
-	"fmt"
-	"image/color"
-	"math"
-	"strconv"
-	"strings"
+        "fmt"
+        "image/color"
+        "math"
+        "strconv"
+        "strings"
 
-	"github.com/hajimehoshi/ebiten/v2"
-	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
-	"github.com/hajimehoshi/ebiten/v2/inpututil"
+        "github.com/hajimehoshi/ebiten/v2"
+        "github.com/hajimehoshi/ebiten/v2/ebitenutil"
+        "github.com/hajimehoshi/ebiten/v2/inpututil"
+
+        gorillas "github.com/arran4/gorillas"
 )
 
 // playState implements the main gameplay loop.
@@ -160,15 +162,16 @@ func (playState) Update(g *Game) error {
 			g.Throw()
 		}
 
-		g.gamepads = ebiten.AppendGamepadIDs(g.gamepads[:0])
-		for _, id := range g.gamepads {
-			if ebiten.IsStandardGamepadLayoutAvailable(id) {
-				lx, ly := ebiten.StandardGamepadLayout(id).LeftStickPosition()
-				if lx < -0.2 {
-					g.Angle += 1
-				}
-				if lx > 0.2 {
-					g.Angle -= 1
+                g.gamepads = ebiten.AppendGamepadIDs(g.gamepads[:0])
+                for _, id := range g.gamepads {
+                        if ebiten.IsStandardGamepadLayoutAvailable(id) {
+                                lx := ebiten.StandardGamepadAxisValue(id, ebiten.StandardGamepadAxisLeftStickHorizontal)
+                                ly := ebiten.StandardGamepadAxisValue(id, ebiten.StandardGamepadAxisLeftStickVertical)
+                                if lx < -0.2 {
+                                        g.Angle += 1
+                                }
+                                if lx > 0.2 {
+                                        g.Angle -= 1
 				}
 				if ly < -0.2 {
 					g.Power += 1
@@ -302,8 +305,8 @@ func (playState) Draw(g *Game, screen *ebiten.Image) {
 		x := (g.Width - len(msg)*charW) / 2
 		y := g.Height/2 - charH/2
 		ebitenutil.DebugPrintAt(screen, msg, x, y)
-	} else if g.LastEvent != EventNone {
-		msg := gorillas.EventMessage(g.LastEvent)
+        } else if g.LastEvent != gorillas.EventNone {
+                msg := gorillas.EventMessage(g.LastEvent)
 		x := (g.Width - len(msg)*charW) / 2
 		y := g.Height / 3
 		ebitenutil.DebugPrintAt(screen, msg, x, y)


### PR DESCRIPTION
## Summary
- import gorillas package in ebiten player state
- replace removed gamepad API with axis values
- reference EventNone constant from gorillas package

## Testing
- `go list ./...`
- `go vet ./...` *(fails: X11 and ALSA dev files missing)*
- `go test ./...` *(fails: X11 and ALSA dev files missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d348ecc4c832fb29efcfe16c770a4