### PR TITLE
Fix taunt display loop

### DIFF
--- a/cmd/gorillia-ebiten/play_state.go
+++ b/cmd/gorillia-ebiten/play_state.go
@@ -3,17 +3,17 @@
 package main
 
 import (
-        "fmt"
-        "image/color"
-        "math"
-        "strconv"
-        "strings"
+	"fmt"
+	"image/color"
+	"math"
+	"strconv"
+	"strings"
 
-        "github.com/hajimehoshi/ebiten/v2"
-        "github.com/hajimehoshi/ebiten/v2/ebitenutil"
-        "github.com/hajimehoshi/ebiten/v2/inpututil"
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
 
-        gorillas "github.com/arran4/gorillas"
+	gorillas "github.com/arran4/gorillas"
 )
 
 // playState implements the main gameplay loop.
@@ -162,16 +162,16 @@ func (playState) Update(g *Game) error {
 			g.Throw()
 		}
 
-                g.gamepads = ebiten.AppendGamepadIDs(g.gamepads[:0])
-                for _, id := range g.gamepads {
-                        if ebiten.IsStandardGamepadLayoutAvailable(id) {
-                                lx := ebiten.StandardGamepadAxisValue(id, ebiten.StandardGamepadAxisLeftStickHorizontal)
-                                ly := ebiten.StandardGamepadAxisValue(id, ebiten.StandardGamepadAxisLeftStickVertical)
-                                if lx < -0.2 {
-                                        g.Angle += 1
-                                }
-                                if lx > 0.2 {
-                                        g.Angle -= 1
+		g.gamepads = ebiten.AppendGamepadIDs(g.gamepads[:0])
+		for _, id := range g.gamepads {
+			if ebiten.IsStandardGamepadLayoutAvailable(id) {
+				lx := ebiten.StandardGamepadAxisValue(id, ebiten.StandardGamepadAxisLeftStickHorizontal)
+				ly := ebiten.StandardGamepadAxisValue(id, ebiten.StandardGamepadAxisLeftStickVertical)
+				if lx < -0.2 {
+					g.Angle += 1
+				}
+				if lx > 0.2 {
+					g.Angle -= 1
 				}
 				if ly < -0.2 {
 					g.Power += 1
@@ -305,8 +305,8 @@ func (playState) Draw(g *Game, screen *ebiten.Image) {
 		x := (g.Width - len(msg)*charW) / 2
 		y := g.Height/2 - charH/2
 		ebitenutil.DebugPrintAt(screen, msg, x, y)
-        } else if g.LastEvent != gorillas.EventNone {
-                msg := gorillas.EventMessage(g.LastEvent)
+	} else if g.LastEvent != gorillas.EventNone {
+		msg := g.LastEventMsg
 		x := (g.Width - len(msg)*charW) / 2
 		y := g.Height / 3
 		ebitenutil.DebugPrintAt(screen, msg, x, y)

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -273,7 +273,7 @@ func (g *Game) draw() {
 		msg := "Abort game? [Y/N]"
 		drawString(g.screen, (g.Width-len(msg))/2, 1, msg)
 	} else if g.LastEvent != gorillas.EventNone {
-		msg := gorillas.EventMessage(g.LastEvent)
+		msg := g.LastEventMsg
 		drawString(g.screen, (g.Width-len(msg))/2, g.Height/3, msg)
 	}
 	g.screen.Show()

--- a/game.go
+++ b/game.go
@@ -204,6 +204,10 @@ type Game struct {
 
 	// LastEvent records the outcome of the most recent shot.
 	LastEvent ShotEvent
+	// LastEventTicks counts down the display duration of LastEvent.
+	LastEventTicks int
+	// LastEventMsg stores the random message associated with LastEvent.
+	LastEventMsg string
 
 	lastStartX float64
 	lastOtherX float64
@@ -220,6 +224,7 @@ const defaultShotsFile = "gorillas_shots.json"
 const defaultLeagueFile = "gorillas.lge"
 const groundBounceFactor = 0.4
 const groundBounceThreshold = 5.0
+const eventDisplayTicks = 40
 
 func NewGame(width, height, buildingCount int) *Game {
 	if buildingCount <= 0 {
@@ -439,11 +444,20 @@ func (g *Game) Throw() {
 	g.Banana.VY = -math.Sin(radians) * speed
 	g.lastVX = g.Banana.VX
 	g.LastEvent = EventNone
+	g.LastEventTicks = 0
+	g.LastEventMsg = ""
 	g.Banana.Active = true
 }
 
 func (g *Game) Step() ShotEvent {
 	g.stepVictoryDance()
+	if g.LastEventTicks > 0 {
+		g.LastEventTicks--
+		if g.LastEventTicks == 0 {
+			g.LastEvent = EventNone
+			g.LastEventMsg = ""
+		}
+	}
 	if g.Explosion.Active {
 		if g.Explosion.Frame < len(g.Explosion.Radii)-1 {
 			g.Explosion.Frame++
@@ -512,6 +526,8 @@ func (g *Game) Step() ShotEvent {
 				winner = (shooter + 1) % 2
 				event = EventSelf
 				g.LastEvent = event
+				g.LastEventTicks = eventDisplayTicks
+				g.LastEventMsg = EventMessage(event)
 			}
 			g.Wins[winner]++
 			g.TotalWins[winner]++
@@ -572,6 +588,8 @@ func (g *Game) evaluateMiss() {
 	dxShot := g.Banana.X - g.lastStartX
 	if g.lastVX*dxToOther < 0 {
 		g.LastEvent = EventBackwards
+		g.LastEventTicks = eventDisplayTicks
+		g.LastEventMsg = EventMessage(EventBackwards)
 		if g.Settings.UseSound {
 			PlayBeep()
 		}
@@ -579,6 +597,8 @@ func (g *Game) evaluateMiss() {
 	}
 	if math.Abs(dxShot) < math.Abs(dxToOther)/3 {
 		g.LastEvent = EventWeak
+		g.LastEventTicks = eventDisplayTicks
+		g.LastEventMsg = EventMessage(EventWeak)
 		if g.Settings.UseSound {
 			PlayBeep()
 		}


### PR DESCRIPTION
## Summary
- keep selected taunt message instead of rerandomizing each frame
- draw stored taunt message in both UIs

## Testing
- `go test ./...` *(fails: `X11/extensions/Xrandr.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d365efe58832f9398b5e9190cbf7b