### PR TITLE
Improve editing behavior in setup menus

### DIFF
--- a/cmd/gorillia-ebiten/setup_state.go
+++ b/cmd/gorillia-ebiten/setup_state.go
@@ -123,6 +123,45 @@ func (s *setupState) Update(g *Game) error {
 			return nil
 		}
 
+		// Automatically start editing when typing or pressing backspace
+		// on the selected field or player.
+		if k != ebiten.KeyN && k != ebiten.KeyD && k != ebiten.KeyR {
+			if k == ebiten.KeyBackspace || keyToRune(k) != 0 {
+				if s.cur < len(s.fields) {
+					s.editing = true
+					s.editingPlayer = -1
+					if k == ebiten.KeyBackspace {
+						if len(s.fields[s.cur]) > 0 {
+							s.fields[s.cur] = s.fields[s.cur][:len(s.fields[s.cur])-1]
+						}
+					} else {
+						r := keyToRune(k)
+						if s.cur >= 2 {
+							if (r >= '0' && r <= '9') || (s.cur == 3 && r == '.') {
+								s.fields[s.cur] += string(r)
+							}
+						} else {
+							s.fields[s.cur] += string(r)
+						}
+					}
+					continue
+				} else if s.cur >= len(s.fields) && s.cur < len(s.fields)+len(s.players) {
+					s.editing = true
+					s.editingPlayer = s.cur - len(s.fields)
+					s.oldName = s.players[s.editingPlayer]
+					s.newPlayer = false
+					if k == ebiten.KeyBackspace {
+						if len(s.players[s.editingPlayer]) > 0 {
+							s.players[s.editingPlayer] = s.players[s.editingPlayer][:len(s.players[s.editingPlayer])-1]
+						}
+					} else {
+						s.players[s.editingPlayer] += string(keyToRune(k))
+					}
+					continue
+				}
+			}
+		}
+
 		switch k {
 		case ebiten.KeyEscape:
 			r, _ := strconv.Atoi(s.fields[2])

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -662,6 +662,44 @@ func setupScreen(s tcell.Screen, league *gorillas.League, p1, p2 string, rounds 
 				continue
 			}
 
+			// Automatically enter editing mode when typing or
+			// pressing backspace on a selected field or player.
+			if key.Key() == tcell.KeyBackspace || key.Key() == tcell.KeyBackspace2 || key.Rune() != 0 {
+				if cur < len(fields) {
+					editing = true
+					editingPlayer = -1
+					if key.Key() == tcell.KeyBackspace || key.Key() == tcell.KeyBackspace2 {
+						if len(fields[cur]) > 0 {
+							fields[cur] = fields[cur][:len(fields[cur])-1]
+						}
+					} else {
+						r := key.Rune()
+						if cur >= 2 {
+							if r >= '0' && r <= '9' {
+								fields[cur] += string(r)
+							}
+						} else {
+							fields[cur] += string(r)
+						}
+					}
+					continue
+				} else if cur >= len(fields) && cur < len(fields)+len(players) {
+					editing = true
+					editingPlayer = cur - len(fields)
+					oldName = players[editingPlayer]
+					newPlayer = false
+					selectedPlayer = editingPlayer
+					if key.Key() == tcell.KeyBackspace || key.Key() == tcell.KeyBackspace2 {
+						if len(players[editingPlayer]) > 0 {
+							players[editingPlayer] = players[editingPlayer][:len(players[editingPlayer])-1]
+						}
+					} else {
+						players[editingPlayer] += string(key.Rune())
+					}
+					continue
+				}
+			}
+
 			switch key.Key() {
 			case tcell.KeyEsc:
 				r, _ := strconv.Atoi(fields[2])


### PR DESCRIPTION
## Summary
- make text fields in the tcell setup screen automatically enter editing mode
  when typing or pressing backspace
- do the same for the ebiten setup screen

## Testing
- `go test ./...` *(fails: missing build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d3d252b08832fb631025c56b77aa6