### PR TITLE
Enable circular blast holes

### DIFF
--- a/cmd/gorillia-ebiten/play_state.go
+++ b/cmd/gorillia-ebiten/play_state.go
@@ -3,17 +3,17 @@
 package main
 
 import (
-        "fmt"
-        "image/color"
-        "math"
-        "strconv"
-        "strings"
+	"fmt"
+	"image/color"
+	"math"
+	"strconv"
+	"strings"
 
-        "github.com/hajimehoshi/ebiten/v2"
-        "github.com/hajimehoshi/ebiten/v2/ebitenutil"
-        "github.com/hajimehoshi/ebiten/v2/inpututil"
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
 
-        gorillas "github.com/arran4/gorillas"
+	gorillas "github.com/arran4/gorillas"
 )
 
 // playState implements the main gameplay loop.
@@ -162,16 +162,16 @@ func (playState) Update(g *Game) error {
 			g.Throw()
 		}
 
-                g.gamepads = ebiten.AppendGamepadIDs(g.gamepads[:0])
-                for _, id := range g.gamepads {
-                        if ebiten.IsStandardGamepadLayoutAvailable(id) {
-                                lx := ebiten.StandardGamepadAxisValue(id, ebiten.StandardGamepadAxisLeftStickHorizontal)
-                                ly := ebiten.StandardGamepadAxisValue(id, ebiten.StandardGamepadAxisLeftStickVertical)
-                                if lx < -0.2 {
-                                        g.Angle += 1
-                                }
-                                if lx > 0.2 {
-                                        g.Angle -= 1
+		g.gamepads = ebiten.AppendGamepadIDs(g.gamepads[:0])
+		for _, id := range g.gamepads {
+			if ebiten.IsStandardGamepadLayoutAvailable(id) {
+				lx := ebiten.StandardGamepadAxisValue(id, ebiten.StandardGamepadAxisLeftStickHorizontal)
+				ly := ebiten.StandardGamepadAxisValue(id, ebiten.StandardGamepadAxisLeftStickVertical)
+				if lx < -0.2 {
+					g.Angle += 1
+				}
+				if lx > 0.2 {
+					g.Angle -= 1
 				}
 				if ly < -0.2 {
 					g.Power += 1
@@ -209,27 +209,20 @@ func (playState) Update(g *Game) error {
 
 func (playState) Draw(g *Game, screen *ebiten.Image) {
 	screen.Fill(color.RGBA{0, 0, 0, 255})
-	for i := range g.buildings {
-		g.buildings[i].h = g.Buildings[i].H
-		g.buildings[i].damage = g.buildings[i].damage[:0]
+	bw := float64(g.Width) / float64(g.Game.BuildingCount)
+	for i := 0; i < g.Game.BuildingCount; i++ {
+		h := g.Buildings[i].H
+		img := g.buildingImg[i]
+		img.Fill(color.RGBA{})
+		img.DrawImage(g.buildingBase[i], nil)
 		for _, d := range g.Buildings[i].Damage {
-			g.buildings[i].damage = append(g.buildings[i].damage, damageRect{
-				x: d.X,
-				y: d.Y,
-				w: d.W,
-				h: d.H,
-			})
+			rx := int(d.X - float64(i)*bw)
+			ry := int(d.Y - (float64(g.Height) - h))
+			clearCircle(img, rx, ry, d.R)
 		}
-	}
-	for i, b := range g.buildings {
-		ebitenutil.DrawRect(screen, b.x, float64(g.Height)-b.h, b.w-1, b.h, b.color)
-		for _, w := range b.windows {
-			ebitenutil.DrawRect(screen, w.x, w.y, w.w, w.h, color.RGBA{255, 255, 0, 255})
-		}
-		for _, d := range b.damage {
-			ebitenutil.DrawRect(screen, d.x, d.y, d.w, d.h, color.Black)
-		}
-		_ = i
+		op := &ebiten.DrawImageOptions{}
+		op.GeoM.Translate(float64(i)*bw, float64(g.Height)-h)
+		screen.DrawImage(img, op)
 	}
 	for i := range g.Gorillas {
 		g.drawGorilla(screen, i)
@@ -305,8 +298,8 @@ func (playState) Draw(g *Game, screen *ebiten.Image) {
 		x := (g.Width - len(msg)*charW) / 2
 		y := g.Height/2 - charH/2
 		ebitenutil.DebugPrintAt(screen, msg, x, y)
-        } else if g.LastEvent != gorillas.EventNone {
-                msg := gorillas.EventMessage(g.LastEvent)
+	} else if g.LastEvent != gorillas.EventNone {
+		msg := gorillas.EventMessage(g.LastEvent)
 		x := (g.Width - len(msg)*charW) / 2
 		y := g.Height / 3
 		ebitenutil.DebugPrintAt(screen, msg, x, y)

--- a/game.go
+++ b/game.go
@@ -9,13 +9,13 @@ import (
 	"os"
 )
 
-type DamageRect struct {
-	X, Y, W, H float64
+type DamageCircle struct {
+	X, Y, R float64
 }
 
 type Building struct {
 	X, W, H float64
-	Damage  []DamageRect
+	Damage  []DamageCircle
 }
 
 type Gorilla struct {
@@ -327,14 +327,67 @@ func (g *Game) recordExplosionDamage(x, y, r float64) {
 		bx2 := b.X + b.W
 		by1 := float64(g.Height) - b.H
 		by2 := float64(g.Height)
-		left := math.Max(bx1, x-r)
-		right := math.Min(bx2, x+r)
-		top := math.Max(by1, y-r)
-		bottom := math.Min(by2, y+r)
-		if left < right && top < bottom {
-			b.Damage = append(b.Damage, DamageRect{left, top, right - left, bottom - top})
+		if x+r <= bx1 || x-r >= bx2 || y+r <= by1 || y-r >= by2 {
+			continue
+		}
+		b.Damage = append(b.Damage, DamageCircle{x, y, r})
+	}
+}
+
+func (g *Game) pointInDamage(idx int, x, y float64) bool {
+	b := &g.Buildings[idx]
+	for _, d := range b.Damage {
+		dx := x - d.X
+		dy := y - d.Y
+		if dx*dx+dy*dy <= d.R*d.R {
+			return true
 		}
 	}
+	return false
+}
+
+func (g *Game) startExplosion(x, y float64) {
+	base := g.Settings.NewExplosionRadius
+	if base <= 0 {
+		base = 16
+	}
+	if g.Settings.ForceCGA {
+		base /= 2
+	}
+	if g.Settings.UseSound {
+		PlayExplosionMelody()
+	}
+	g.Explosion = Explosion{X: x, Y: y}
+	if g.Settings.UseOldExplosions {
+		for i := 1; i <= int(base); i++ {
+			g.Explosion.Radii = append(g.Explosion.Radii, float64(i))
+		}
+		for i := int(base * 1.5); i >= 1; i-- {
+			g.Explosion.Radii = append(g.Explosion.Radii, float64(i))
+		}
+	} else {
+		g.Explosion.Radii = []float64{base * 1.175, base, base * 0.9, base * 0.6, base * 0.45, 0}
+		g.Explosion.Colors = []color.Color{
+			color.RGBA{128, 128, 128, 255},
+			color.RGBA{255, 0, 0, 255},
+			color.RGBA{255, 165, 0, 255},
+			color.RGBA{255, 255, 0, 255},
+			color.RGBA{255, 255, 255, 255},
+			color.Black,
+		}
+		if g.Settings.UseVectorExplosions {
+			frames := []float64{base, base * 0.9, base * 0.6, base * 0.45}
+			for _, r := range frames {
+				w := 2 * r
+				h := 2 * r * 0.825
+				offX := x - r
+				offY := y - r*0.825
+				g.Explosion.Vectors = append(g.Explosion.Vectors, scaleVector(vectorData, w, h, offX, offY))
+			}
+		}
+	}
+	g.Explosion.Active = true
+	g.recordExplosionDamage(x, y, base)
 }
 
 func (g *Game) startGorillaExplosion(idx int) {
@@ -487,19 +540,12 @@ func (g *Game) Step() ShotEvent {
 	idx := int(g.Banana.X / bw)
 	if idx >= 0 && idx < g.BuildingCount && g.Banana.Y < float64(g.Height) {
 		if g.Banana.Y > float64(g.Height)-g.Buildings[idx].H {
-			// shorten the building to the impact point to simulate
-			// simple environmental destruction
-			newH := float64(g.Height) - g.Banana.Y
-			if newH < 0 {
-				newH = 0
+			if !g.pointInDamage(idx, g.Banana.X, g.Banana.Y) {
+				g.Banana.Active = false
+				g.startExplosion(g.Banana.X, g.Banana.Y)
+				g.evaluateMiss()
+				g.Current = (g.Current + 1) % 2
 			}
-			if newH < g.Buildings[idx].H {
-				g.Buildings[idx].H = newH
-			}
-			g.Banana.Active = false
-			// evaluate shot quality on miss
-			g.evaluateMiss()
-			g.Current = (g.Current + 1) % 2
 		}
 	}
 	for i, gr := range g.Gorillas {

--- a/game_test.go
+++ b/game_test.go
@@ -93,14 +93,11 @@ func TestBuildingCollisionEndsTurn(t *testing.T) {
 	}
 }
 
-func TestBuildingDamageReducesHeight(t *testing.T) {
+func TestBuildingDamageRecorded(t *testing.T) {
 	g := newTestGame()
-	// ensure building 2 is tall and track initial height
 	idx := 2
 	g.Buildings[idx].H = float64(g.Height) - g.Gorillas[0].Y + 10
-	initial := g.Buildings[idx].H
 
-	// aim directly at the side of building 2
 	g.Angle = 0
 	g.Power = 20
 	g.Current = 0
@@ -108,8 +105,33 @@ func TestBuildingDamageReducesHeight(t *testing.T) {
 	g.Throw()
 	g.Step()
 
-	if g.Buildings[idx].H >= initial {
-		t.Fatalf("expected building height to decrease, got %f", g.Buildings[idx].H)
+	if len(g.Buildings[idx].Damage) == 0 {
+		t.Fatal("expected damage to be recorded on building hit")
+	}
+}
+
+func TestBananaPassesThroughDamage(t *testing.T) {
+	g := newTestGame()
+	idx := 2
+	g.Buildings[idx].H = float64(g.Height) - g.Gorillas[0].Y + 10
+
+	g.Angle = 0
+	g.Power = 20
+	g.Current = 0
+
+	g.Throw()
+	g.Step()
+
+	if len(g.Buildings[idx].Damage) == 0 {
+		t.Fatal("damage not recorded")
+	}
+
+	g.Current = 0
+	g.Throw()
+	g.Step()
+
+	if !g.Banana.Active {
+		t.Fatal("banana should pass through damaged section")
 	}
 }
 


### PR DESCRIPTION
## Summary
- store blast damage using circles instead of rectangles
- clip explosions to buildings when tracking damage
- subtract circular holes from building images when drawing
- update collision checks against circular damage
- drop the temporary building struct now that buildings are just images

## Testing
- `go test ./...` *(fails: X11/alsa missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d3697ed98832fb027d2ed9bc8aa28