### PR TITLE
Fix tcell background color

### DIFF
--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -923,10 +923,11 @@ func main() {
 		}
 		panic(err)
 	}
-	if err = s.Init(); err != nil {
-		panic(fmt.Errorf("screen init: %w", err))
-	}
-	defer s.Fini()
+    if err = s.Init(); err != nil {
+            panic(fmt.Errorf("screen init: %w", err))
+    }
+    s.SetStyle(tcell.StyleDefault.Background(tcell.ColorBlack).Foreground(tcell.ColorWhite))
+    defer s.Fini()
 
 	settings := gorillas.LoadSettings()
 	wind := flag.Float64("wind", math.NaN(), "initial wind")


### PR DESCRIPTION
## Summary
- ensure the terminal version always uses a black background

## Testing
- `go test ./...` *(fails: X11/ALSA not available)*

------
https://chatgpt.com/codex/tasks/task_e_685d4f1b8804832fbe2b08fc943fe90b