### PR TITLE
Fix gorilla art parsing

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -289,7 +289,8 @@ func (g *Game) drawGorilla(img *ebiten.Image, idx int) {
 		return
 	}
 	frame := g.gorillaArt[0]
-	baseX := int(g.Gorillas[idx].X) - len(frame[0])*gorillaScale/2
+	width := gorillas.FrameWidth(frame)
+	baseX := int(g.Gorillas[idx].X) - width*gorillaScale/2
 	baseY := int(g.Gorillas[idx].Y) - len(frame)*gorillaScale
 	for dy, line := range frame {
 		for dx, ch := range line {

--- a/cmd/gorillia-tcell/main.go
+++ b/cmd/gorillia-tcell/main.go
@@ -326,7 +326,8 @@ func (g *Game) drawGorilla(idx int) {
 		return
 	}
 	frame := g.gorillaArt[0]
-	x := int(g.Gorillas[idx].X) - len(frame[0])/2
+	width := gorillas.FrameWidth(frame)
+	x := int(g.Gorillas[idx].X) - width/2
 	y := int(g.Gorillas[idx].Y) - len(frame)
 	style := tcell.StyleDefault
 	for dy, line := range frame {
@@ -457,8 +458,8 @@ func (g *Game) run(s tcell.Screen, ai bool) error {
 			}
 			if g.enteringAng || g.enteringPow {
 				now := time.Now()
-                               switch key.Key() {
-                               case tcell.KeyEnter:
+				switch key.Key() {
+				case tcell.KeyEnter:
 					if g.enteringAng {
 						if strings.HasPrefix(g.angleInput, "*") {
 							g.Angle = g.LastAngle[g.Current]
@@ -508,7 +509,7 @@ func (g *Game) run(s tcell.Screen, ai bool) error {
 					}
 				default:
 					r := key.Rune()
-                                       if r == '*' {
+					if r == '*' {
 						if g.enteringAng {
 							if len(g.angleInput) == 0 {
 								g.angleInput = "*"
@@ -519,37 +520,37 @@ func (g *Game) run(s tcell.Screen, ai bool) error {
 							}
 						}
 						g.lastDigit = now
-                                       } else if r == ',' {
-                                               if g.enteringAng {
-                                                       if strings.HasPrefix(g.angleInput, "*") {
-                                                               g.Angle = g.LastAngle[g.Current]
-                                                       } else if v, err := strconv.Atoi(g.angleInput); err == nil {
-                                                               if v < 0 {
-                                                                       v = 0
-                                                               } else if v > 360 {
-                                                                       v = 360
-                                                               }
-                                                               g.Angle = float64(v)
-                                                       }
-                                                       g.enteringAng = false
-                                                       g.angleInput = ""
-                                                       g.enteringPow = true
-                                               } else if g.enteringPow {
-                                                       if strings.HasPrefix(g.powerInput, "*") {
-                                                               g.Power = g.LastPower[g.Current]
-                                                       } else if v, err := strconv.Atoi(g.powerInput); err == nil {
-                                                               if v < 0 {
-                                                                       v = 0
-                                                               } else if v > 200 {
-                                                                       v = 200
-                                                               }
-                                                               g.Power = float64(v)
-                                                       }
-                                                       g.enteringPow = false
-                                                       g.powerInput = ""
-                                                       g.throw()
-                                               }
-                                       } else if r >= '0' && r <= '9' {
+					} else if r == ',' {
+						if g.enteringAng {
+							if strings.HasPrefix(g.angleInput, "*") {
+								g.Angle = g.LastAngle[g.Current]
+							} else if v, err := strconv.Atoi(g.angleInput); err == nil {
+								if v < 0 {
+									v = 0
+								} else if v > 360 {
+									v = 360
+								}
+								g.Angle = float64(v)
+							}
+							g.enteringAng = false
+							g.angleInput = ""
+							g.enteringPow = true
+						} else if g.enteringPow {
+							if strings.HasPrefix(g.powerInput, "*") {
+								g.Power = g.LastPower[g.Current]
+							} else if v, err := strconv.Atoi(g.powerInput); err == nil {
+								if v < 0 {
+									v = 0
+								} else if v > 200 {
+									v = 200
+								}
+								g.Power = float64(v)
+							}
+							g.enteringPow = false
+							g.powerInput = ""
+							g.throw()
+						}
+					} else if r >= '0' && r <= '9' {
 						if now.Sub(g.lastDigit) > digitBufferTimeout {
 							if g.enteringAng {
 								g.angleInput = string(r)

--- a/gorilla_art.go
+++ b/gorilla_art.go
@@ -20,16 +20,39 @@ func LoadGorillaArt(path string) ([][]string, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.TrimSpace(line) == "===" {
+			cur = trimBlankLines(cur)
 			if len(cur) > 0 {
 				frames = append(frames, cur)
-				cur = []string{}
 			}
+			cur = []string{}
 			continue
 		}
-		cur = append(cur, line)
+		cur = append(cur, strings.TrimRight(line, " \t"))
 	}
+	cur = trimBlankLines(cur)
 	if len(cur) > 0 {
 		frames = append(frames, cur)
 	}
 	return frames, scanner.Err()
+}
+
+func trimBlankLines(lines []string) []string {
+	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// FrameWidth returns the maximum line width of a frame of ASCII art.
+func FrameWidth(frame []string) int {
+	w := 0
+	for _, line := range frame {
+		if len(line) > w {
+			w = len(line)
+		}
+	}
+	return w
 }


### PR DESCRIPTION
## Summary
- trim blank lines when splitting gorilla art frames
- simplify the frame parsing loop

## Testing
- `go test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d4efbe894832f8a397ff55f778859