### PR TITLE
Limit skyline height

### DIFF
--- a/game.go
+++ b/game.go
@@ -279,8 +279,8 @@ func NewGame(width, height, buildingCount int) *Game {
 		if h < float64(height)*0.1 {
 			h = float64(height) * 0.1
 		}
-		if h > float64(height)*0.9 {
-			h = float64(height) * 0.9
+		if h > float64(height)*0.8 {
+			h = float64(height) * 0.8
 		}
 
 		g.Buildings = append(g.Buildings, Building{


### PR DESCRIPTION
## Summary
- restrict max building height to 80% of the screen

## Testing
- `go test ./...` *(fails: X11/alsa dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685dc9492e78832f978380511e8f9350