### PR TITLE
Preserve ResetHook across rounds

### DIFF
--- a/game.go
+++ b/game.go
@@ -303,6 +303,7 @@ func (g *Game) Reset() {
 	league := g.League
 	settings := g.Settings
 	gravity := g.Gravity
+	hook := g.ResetHook
 	*g = *NewGame(g.Width, g.Height, g.BuildingCount)
 	g.Wins = wins
 	g.TotalWins = totals
@@ -312,6 +313,7 @@ func (g *Game) Reset() {
 	g.League = league
 	g.Settings = settings
 	g.Gravity = gravity
+	g.ResetHook = hook
 	if g.ResetHook != nil {
 		g.ResetHook()
 	}


### PR DESCRIPTION
## Summary
- ensure ResetHook survives round resets so UI state refreshes

## Testing
- `go vet ./...` *(fails: `X11/extensions/Xrandr.h: No such file or directory`)*
- `go test ./...` *(fails: `Xrandr.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_685dcc4975cc832f86438426f5d56177