### PR TITLE
Fix gorilla sprite size and use QBASIC drawing

### DIFF
--- a/cmd/gorillia-ebiten/constants.go
+++ b/cmd/gorillia-ebiten/constants.go
@@ -8,10 +8,20 @@ const (
 	charW = 6
 	charH = 16
 	// gorillaScale controls how large the gorilla sprite appears in game
-	gorillaScale = 4
+	// The previous value of 4 produced gorillas far larger than the
+	// buildings drawn at 800x600, so reduce this to better match the
+	// original QBASIC proportions.
+	gorillaScale = 2
 	// bananaScale and sunScale keep other sprites proportional to the gorilla
 	bananaScale = gorillaScale
 	sunScale    = gorillaScale
+)
+
+// Constants describing the gorilla arm positions when drawing.
+const (
+	armsRightUp = 1
+	armsLeftUp  = 2
+	armsDown    = 3
 )
 
 // gorillaFrames represents the ASCII gorilla animation frames shared by

--- a/cmd/gorillia-ebiten/graphics.go
+++ b/cmd/gorillia-ebiten/graphics.go
@@ -76,12 +76,16 @@ func drawBASSun(img *ebiten.Image, cx, cy, r float64, shocked bool, clr color.Co
 }
 
 // drawBASGorilla draws a simple approximation of the BAS gorilla sprite.
-func drawBASGorilla(img *ebiten.Image, x, y, scale float64, clr color.Color) {
+func drawBASGorilla(img *ebiten.Image, x, y, scale float64, arms int, clr color.Color) {
 	S := func(v float64) float64 { return v * scale }
 	// head
 	drawFilledRect(img, x-S(4), y, x+S(2.9), y+S(6), clr)
 	drawFilledRect(img, x-S(5), y+S(2), x+S(4), y+S(4), clr)
 	ebitenutil.DrawLine(img, x-S(3), y+S(2), x+S(2), y+S(2), color.Black)
+	for i := -2.0; i <= -1.0; i++ {
+		ebitenutil.DrawRect(img, x+S(i), y+S(4), 1, 1, color.Black)
+		ebitenutil.DrawRect(img, x+S(i+3), y+S(4), 1, 1, color.Black)
+	}
 	// neck
 	ebitenutil.DrawLine(img, x-S(3), y+S(7), x+S(2), y+S(7), clr)
 	// body
@@ -95,4 +99,17 @@ func drawBASGorilla(img *ebiten.Image, x, y, scale float64, clr color.Color) {
 	// chest outline
 	drawArc(img, x-S(4.9), y+S(10), S(4.9), 270, 360, color.Black)
 	drawArc(img, x+S(4.9), y+S(10), S(4.9), 180, 270, color.Black)
+	for i := -5.0; i <= -1.0; i++ {
+		switch arms {
+		case armsRightUp:
+			drawArc(img, x+S(i-0.1), y+S(14), S(9), 135, 225, clr)
+			drawArc(img, x+S(4.9)+S(i), y+S(4), S(9), 315, 45, clr)
+		case armsLeftUp:
+			drawArc(img, x+S(i-0.1), y+S(4), S(9), 135, 225, clr)
+			drawArc(img, x+S(4.9)+S(i), y+S(14), S(9), 315, 45, clr)
+		default:
+			drawArc(img, x+S(i-0.1), y+S(14), S(9), 135, 225, clr)
+			drawArc(img, x+S(4.9)+S(i), y+S(14), S(9), 315, 45, clr)
+		}
+	}
 }

--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -111,7 +111,7 @@ func defaultGorillaSprite() *ebiten.Image {
 	size := int(30 * gorillaScale)
 	img := ebiten.NewImage(size, size)
 	clr := color.RGBA{150, 75, 0, 255}
-	drawBASGorilla(img, 15*gorillaScale, gorillaScale, gorillaScale, clr)
+	drawBASGorilla(img, 15*gorillaScale, gorillaScale, gorillaScale, armsDown, clr)
 	return img
 }
 
@@ -282,8 +282,8 @@ func (g *Game) drawWindArrow(img *ebiten.Image) {
 		return
 	}
 	length := g.Wind * 3 * float64(g.Width) / 320
-       // Position arrow near the top instead of the bottom
-       y := float64(g.Height) / 40
+	// Position arrow near the top instead of the bottom
+	y := float64(g.Height) / 40
 	x := float64(g.Width) / 2
 	end := x + length
 	ebitenutil.DrawLine(img, x, y, end, y, color.RGBA{255, 255, 0, 255})


### PR DESCRIPTION
## Summary
- shrink gorillaScale so sprites match building size
- port gorilla drawing routine from QBASIC including arm positions

## Testing
- `go test ./...` *(fails: X11 and ALSA headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_685dceadadf0832f9bd1b59e205b53cb