### PR TITLE
Add ESC skip for intro animations

### DIFF
--- a/cmd/gorillia-ebiten/intro.go
+++ b/cmd/gorillia-ebiten/intro.go
@@ -161,7 +161,10 @@ func (g *introScreenGame) Update() error {
 	now := time.Now()
 	switch g.stage {
 	case 0:
-		if now.After(g.next) {
+		if inpututil.IsKeyJustPressed(ebiten.KeyEscape) {
+			g.stage = 1
+			g.frame = 0
+		} else if now.After(g.next) {
 			g.frame++
 			g.next = now.Add(300 * time.Millisecond)
 			if g.frame >= 4 {

--- a/cmd/gorillia-ebiten/menu_state.go
+++ b/cmd/gorillia-ebiten/menu_state.go
@@ -28,7 +28,10 @@ func (m *menuState) Update(g *Game) error {
 	now := time.Now()
 	switch m.stage {
 	case 0:
-		if now.After(m.next) {
+		if inpututil.IsKeyJustPressed(ebiten.KeyEscape) {
+			m.stage = 1
+			m.frame = 0
+		} else if now.After(m.next) {
 			m.frame++
 			m.next = now.Add(300 * time.Millisecond)
 			if m.frame >= 4 {

--- a/cmd/gorillia-tcell/intro.go
+++ b/cmd/gorillia-tcell/intro.go
@@ -176,7 +176,9 @@ func introScreen(s tcell.Screen, useSound, sliding bool) bool {
 		drawGorillaFrame(s, cx+12, cy, gorillaFrames[(i+1)%len(gorillaFrames)])
 		drawString(s, w/2-4, cy-2, "GORILLAS")
 		s.Show()
-		time.Sleep(300 * time.Millisecond)
+		if waitEsc(s, 300*time.Millisecond) {
+			break
+		}
 	}
 	for {
 		s.Clear()


### PR DESCRIPTION
## Summary
- allow skipping intro animation frames on the menu with `ESC`
- add the same `ESC` handling to the Ebiten frontend

## Testing
- `go test ./...` *(fails: X11/ALSA missing)*

------
https://chatgpt.com/codex/tasks/task_e_685dcf426488832f9eb0a869171b97f8