### PR TITLE
Improve skyline and graphics accuracy

### DIFF
--- a/cmd/gorillia-ebiten/graphics.go
+++ b/cmd/gorillia-ebiten/graphics.go
@@ -33,10 +33,10 @@ func drawFilledCircle(img *ebiten.Image, cx, cy, r float64, clr color.Color) {
 func drawArc(img *ebiten.Image, cx, cy, r float64, startDeg, endDeg float64, clr color.Color) {
 	step := 2.0
 	prevX := cx + r*math.Cos(startDeg*math.Pi/180)
-	prevY := cy + r*math.Sin(startDeg*math.Pi/180)
+	prevY := cy - r*math.Sin(startDeg*math.Pi/180)
 	for a := startDeg + step; a <= endDeg; a += step {
 		x := cx + r*math.Cos(a*math.Pi/180)
-		y := cy + r*math.Sin(a*math.Pi/180)
+		y := cy - r*math.Sin(a*math.Pi/180)
 		ebitenutil.DrawLine(img, prevX, prevY, x, y, clr)
 		prevX, prevY = x, y
 	}

--- a/game.go
+++ b/game.go
@@ -252,7 +252,7 @@ func NewGame(width, height, buildingCount int) *Game {
 	if slope == 2 || slope == 6 {
 		newHt = float64(height) * 0.6
 	}
-	htInc := float64(height) / 25
+	htInc := float64(height) / 35
 
 	for i := 0; i < g.BuildingCount; i++ {
 		x := float64(i) * bw
@@ -275,12 +275,12 @@ func NewGame(width, height, buildingCount int) *Game {
 			}
 		}
 
-		h := newHt + rand.Float64()*float64(height)/4
-		if h < float64(height)*0.1 {
-			h = float64(height) * 0.1
+		h := newHt + rand.Float64()*float64(height)/6 - float64(height)/12
+		if h < float64(height)*0.15 {
+			h = float64(height) * 0.15
 		}
-		if h > float64(height)*0.8 {
-			h = float64(height) * 0.8
+		if h > float64(height)*0.6 {
+			h = float64(height) * 0.6
 		}
 
 		g.Buildings = append(g.Buildings, Building{


### PR DESCRIPTION
## Summary
- flatten slope step for shorter buildings
- clamp building heights and randomise more
- fix arc orientation so the sun (and gorillas) render correctly

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685dd04d6d48832f9914c25a58910d64