### PR TITLE
Fix gorilla collision detection

### DIFF
--- a/game_test.go
+++ b/game_test.go
@@ -218,6 +218,30 @@ func TestGorillaHitIncrementsWin(t *testing.T) {
 	}
 }
 
+func TestHighSpeedGorillaHit(t *testing.T) {
+	g := newTestGame()
+	g.Angle = 0
+	g.Power = 100
+	g.Current = 0
+	for i := range g.Buildings {
+		g.Buildings[i].H = 0
+	}
+	startX := g.Gorillas[0].X
+	startY := g.Gorillas[0].Y
+	vx := math.Cos(g.Angle*math.Pi/180) * (g.Power / 2)
+	g.Gorillas[1] = Gorilla{X: startX + vx*0.5, Y: startY}
+
+	g.Throw()
+	g.Step()
+
+	if g.Wins[0] != 1 {
+		t.Fatalf("expected player 1 to score, wins: %v", g.Wins)
+	}
+	if !g.roundOver {
+		t.Fatal("round should be over after direct hit")
+	}
+}
+
 func TestWinnerFirstDisabled(t *testing.T) {
 	g := newTestGame()
 	g.Angle = 45


### PR DESCRIPTION
## Summary
- detect gorilla collisions along the banana's path
- skip the shooter while checking collision path
- add regression test for fast collision cases

## Testing
- `go test -tags test $(go list ./... | grep -v drawings/ebiten | grep -v cmd/gorillia-ebiten)`

------
https://chatgpt.com/codex/tasks/task_e_685ddb9e93cc832f80a5bf40d575ca37