### PR TITLE
Fix gorilla arc wrapping

### DIFF
--- a/drawings/ebiten/graphics.go
+++ b/drawings/ebiten/graphics.go
@@ -46,6 +46,9 @@ func DrawFilledCircle(img *ebiten.Image, cx, cy, r float64, clr color.Color) {
 
 // DrawArc renders an arc from startDeg to endDeg going clockwise from 0 degrees to the right.
 func DrawArc(img *ebiten.Image, cx, cy, r float64, startDeg, endDeg float64, clr color.Color) {
+	if endDeg < startDeg {
+		endDeg += 360
+	}
 	step := 2.0
 	prevX := cx + r*math.Cos(startDeg*math.Pi/180)
 	prevY := cy - r*math.Sin(startDeg*math.Pi/180)

--- a/drawings/img/graphics.go
+++ b/drawings/img/graphics.go
@@ -78,6 +78,9 @@ func DrawFilledCircle(img image.Image, cx, cy, r float64, clr color.Color) {
 
 // DrawArc renders an arc from startDeg to endDeg going clockwise from 0 degrees to the right.
 func DrawArc(img image.Image, cx, cy, r float64, startDeg, endDeg float64, clr color.Color) {
+	if endDeg < startDeg {
+		endDeg += 360
+	}
 	step := 2.0
 	prevX := cx + r*math.Cos(startDeg*math.Pi/180)
 	prevY := cy - r*math.Sin(startDeg*math.Pi/180)


### PR DESCRIPTION
## Summary
- handle angle wrap-around in DrawArc for ebiten and image drawers

## Testing
- `go test ./...` *(fails: X11 and ALSA libraries missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ddd094c58832f934d9f66cce549b5