### PR TITLE
Limit tests to root package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENT Instructions
+
+This repository depends on Ebiten for graphical output which requires X11. To prevent failures in environments without X11, only run the unit tests in the repository root.
+
+## Testing
+Run the following from the repository root whenever tests are required:
+
+```bash
+go test -tags test
+```
+
+Do **not** run `go test ./...` or run tests in subdirectories.


### PR DESCRIPTION
## Summary
- add AGENTS instructions to run tests only in the repo root due to Ebiten's X11 requirement

## Testing
- `go test -tags test`


------
https://chatgpt.com/codex/tasks/task_e_685de152e1f8832f96f2f68859a8a3d2