### PR TITLE
Fix banana-gorilla hit detection

### DIFF
--- a/game.go
+++ b/game.go
@@ -679,21 +679,6 @@ func (g *Game) Step() ShotEvent {
 			return g.LastEvent
 		}
 	}
-	bw := float64(g.Width) / float64(g.BuildingCount)
-	idx := int(g.Banana.X / bw)
-	if idx >= 0 && idx < g.BuildingCount && g.Banana.Y < float64(g.Height) &&
-		g.Banana.Y > float64(g.Height)-g.Buildings[idx].H {
-		if !g.pointInDamage(idx, g.Banana.X, g.Banana.Y) {
-			g.Banana.Active = false
-			g.startExplosion(g.Banana.X, g.Banana.Y)
-			if g.roundOver {
-				return g.LastEvent
-			}
-			g.evaluateMiss()
-			g.setCurrent((g.Current + 1) % 2)
-			return g.LastEvent
-		}
-	}
 	if hit := g.gorillaHitBetween(oldX, oldY, g.Banana.X, g.Banana.Y); hit >= 0 {
 		g.Banana.Active = false
 		g.handleGorillaKill(hit)
@@ -737,6 +722,21 @@ func (g *Game) Step() ShotEvent {
 				PlayBeep()
 			}
 			return event
+		}
+	}
+	bw := float64(g.Width) / float64(g.BuildingCount)
+	idx := int(g.Banana.X / bw)
+	if idx >= 0 && idx < g.BuildingCount && g.Banana.Y < float64(g.Height) &&
+		g.Banana.Y > float64(g.Height)-g.Buildings[idx].H {
+		if !g.pointInDamage(idx, g.Banana.X, g.Banana.Y) {
+			g.Banana.Active = false
+			g.startExplosion(g.Banana.X, g.Banana.Y)
+			if g.roundOver {
+				return g.LastEvent
+			}
+			g.evaluateMiss()
+			g.setCurrent((g.Current + 1) % 2)
+			return g.LastEvent
 		}
 	}
 	if g.Banana.Y > float64(g.Height) || g.Banana.X < 0 || g.Banana.X >= float64(g.Width) {

--- a/game_test.go
+++ b/game_test.go
@@ -242,6 +242,28 @@ func TestHighSpeedGorillaHit(t *testing.T) {
 	}
 }
 
+func TestDirectHitOverBuilding(t *testing.T) {
+	g := newTestGame()
+	g.Angle = 0
+	g.Power = 20
+	g.Current = 0
+
+	startX := g.Gorillas[0].X
+	startY := g.Gorillas[0].Y
+	vx := math.Cos(g.Angle*math.Pi/180) * (g.Power / 2)
+	g.Gorillas[1] = Gorilla{X: startX + vx, Y: startY}
+
+	g.Throw()
+	g.Step()
+
+	if g.Wins[0] != 1 {
+		t.Fatalf("expected player 1 to score, wins: %v", g.Wins)
+	}
+	if !g.roundOver {
+		t.Fatal("round should be over after direct hit")
+	}
+}
+
 func TestWinnerFirstDisabled(t *testing.T) {
 	g := newTestGame()
 	g.Angle = 45


### PR DESCRIPTION
## Summary
- register banana to gorilla collisions before checking building collisions
- add regression test for direct hits when gorillas stand on buildings

## Testing
- `go test -tags test`

------
https://chatgpt.com/codex/tasks/task_e_685df828aa4c832fad868b8166cbfc2a