### PR TITLE
Fix crash reading gorilla sprite before Ebiten starts

### DIFF
--- a/cmd/gorillia-ebiten/main.go
+++ b/cmd/gorillia-ebiten/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/arran4/gorillas"
 	ebdraw "github.com/arran4/gorillas/drawings/ebiten"
+	imgdraw "github.com/arran4/gorillas/drawings/img"
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 )
@@ -79,11 +80,12 @@ func newGame(settings gorillas.Settings, buildings int, wind float64) *Game {
 	} else {
 		g.gorillaArt = [][]string{{" O ", "/|\\", "/ \\"}}
 	}
-	g.gorillaImg = ebdraw.DefaultGorillaSprite(gorillaScale)
+	gorillaBase := imgdraw.DefaultGorillaSprite(gorillaScale)
+	g.gorillaImg = ebiten.NewImageFromImage(gorillaBase)
 	if g.Game.HitMap != nil {
 		for i, gr := range g.Game.Gorillas {
 			g.Game.HitMap.ClearGorilla(int(gr.X), int(gr.Y), i, 4)
-			g.Game.HitMap.DrawGorillaImage(int(gr.X), int(gr.Y), i, g.gorillaImg)
+			g.Game.HitMap.DrawGorillaImage(int(gr.X), int(gr.Y), i, gorillaBase)
 		}
 	}
 	g.LoadScores()


### PR DESCRIPTION
## Summary
- avoid using *ebiten.Image for hitmap initialization
- use image-based gorilla sprite then convert for rendering

## Testing
- `go test -tags test`


------
https://chatgpt.com/codex/tasks/task_e_685dfa9ff44c832fae2beb12f668c6a2