### PR TITLE
Fix explosion kill detection on blast radius

### DIFF
--- a/game.go
+++ b/game.go
@@ -509,7 +509,13 @@ func (g *Game) startExplosion(x, y float64) {
 		}
 	}
 	g.Explosion.Active = true
-	if g.killGorillaIfInRadius(x, y, base) {
+	maxR := base
+	for _, r := range g.Explosion.Radii {
+		if r > maxR {
+			maxR = r
+		}
+	}
+	if g.killGorillaIfInRadius(x, y, maxR) {
 		// handleGorillaKill sets roundOver and other state
 	} else {
 		g.roundOver = false

--- a/game_test.go
+++ b/game_test.go
@@ -300,6 +300,31 @@ func TestExplosionKillsNearbyGorilla(t *testing.T) {
 	}
 }
 
+func TestExplosionBlastRadiusKills(t *testing.T) {
+	g := newTestGame()
+	g.Current = 0
+	base := g.Settings.NewExplosionRadius
+	if base <= 0 {
+		base = 16
+	}
+	if g.Settings.ForceCGA {
+		base /= 2
+	}
+	dist := base * 1.1
+	x := g.Gorillas[1].X
+	y := g.Gorillas[1].Y - dist
+	if y < 0 {
+		y = g.Gorillas[1].Y + dist
+	}
+	g.startExplosion(x, y)
+	if !g.roundOver {
+		t.Fatal("round should end when gorilla in blast radius")
+	}
+	if g.Wins[0] != 1 {
+		t.Fatalf("expected player 1 to score, wins: %v", g.Wins)
+	}
+}
+
 func TestSecondPlayerThrowDirection(t *testing.T) {
 	g := newTestGame()
 	g.Current = 1


### PR DESCRIPTION
## Summary
- kill gorillas if explosion radius reaches them
- test that blast radius can kill a gorilla even without direct impact

## Testing
- `go test -tags test`

------
https://chatgpt.com/codex/tasks/task_e_685e0118bd64832fb45bd6284123ed0e