### PR TITLE
Animated gorilla GIF example

### DIFF
--- a/cmd/tests/drawgorilla/main.go
+++ b/cmd/tests/drawgorilla/main.go
@@ -3,17 +3,17 @@ package main
 import (
 	"image"
 	"image/color"
+	"image/draw"
+	"image/gif"
 	"image/png"
 	"os"
 
 	imgdraw "github.com/arran4/gorillas/drawings/img"
+	"image/color/palette"
 )
 
-func main() {
-	scale := 2.0
-	width, height := 90, 90
+func makeFrame(scale float64, width, height int, arms int) *image.Paletted {
 	img := image.NewRGBA(image.Rect(0, 0, width, height))
-
 	sky := color.RGBA{0, 0, 170, 255}
 	for y := 0; y < height; y++ {
 		for x := 0; x < width; x++ {
@@ -21,17 +21,57 @@ func main() {
 		}
 	}
 
-	orange := color.RGBA{255, 170, 85, 255}
+	// Coordinates for the gorilla
 	x := (float64(width) + scale) / 2
 	y := (float64(height) - 23*scale) / 2
-	imgdraw.DrawBASGorilla(img, x, y, scale, imgdraw.ArmsDown, orange)
 
-	f, err := os.Create("gorilla.png")
+	// Draw building under gorilla feet
+	bW := int(20 * scale)
+	bH := height - int(y+23*scale)
+	if bH < 1 {
+		bH = 1
+	}
+	building := imgdraw.CreateBuildingSprite(float64(bW), float64(bH), color.RGBA{100, 100, 100, 255})
+	bx := int(x - float64(bW)/2 + 0.5)
+	by := height - bH
+	draw.Draw(img, image.Rect(bx, by, bx+bW, by+bH), building, image.Point{}, draw.Over)
+
+	orange := color.RGBA{255, 170, 85, 255}
+	imgdraw.DrawBASGorilla(img, x, y, scale, arms, orange)
+
+	pal := image.NewPaletted(img.Bounds(), palette.Plan9)
+	draw.FloydSteinberg.Draw(pal, img.Bounds(), img, image.Point{})
+	return pal
+}
+
+func main() {
+	scale := 2.0
+	width, height := 90, 90
+
+	frames := []int{imgdraw.ArmsDown, imgdraw.ArmsRightUp, imgdraw.ArmsDown, imgdraw.ArmsLeftUp}
+	outGIF := &gif.GIF{}
+	for _, arm := range frames {
+		frame := makeFrame(scale, width, height, arm)
+		outGIF.Image = append(outGIF.Image, frame)
+		outGIF.Delay = append(outGIF.Delay, 100) // 100*10ms = 1s
+	}
+
+	// Also save the first frame as PNG for convenience
+	fPNG, err := os.Create("gorilla.png")
 	if err != nil {
 		panic(err)
 	}
-	defer f.Close()
-	if err := png.Encode(f, img); err != nil {
+	if err := png.Encode(fPNG, outGIF.Image[0]); err != nil {
+		panic(err)
+	}
+	fPNG.Close()
+
+	fGIF, err := os.Create("gorilla.gif")
+	if err != nil {
+		panic(err)
+	}
+	defer fGIF.Close()
+	if err := gif.EncodeAll(fGIF, outGIF); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
## Summary
- update `drawgorilla` demo to draw a building under the gorilla
- animate the gorilla arms in a GIF (down, right-up, down, left-up)

## Testing
- `go test -tags test`

------
https://chatgpt.com/codex/tasks/task_e_685e0177689c832fbb6e615a446e620f