### PR TITLE
Enable single-target build releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*.*.*'
 
 jobs:
-  goreleaser:
+  build:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -23,10 +23,42 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc libc6-dev libgl1-mesa-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev libxxf86vm-dev libasound2-dev pkg-config
-      - uses: goreleaser/goreleaser-action@v5
+      - name: Build
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --clean --single-target
+          args: build --clean --single-target
         env:
           CGO_ENABLED: '1'
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: dist/*
+          retention-days: 1
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+      - name: Ensure Release Exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" -t "$TAG" -n ""
+          fi
+      - name: Upload Release Assets
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            dist/**
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- build single-target binaries on each platform with GoReleaser
- create a release for tag pushes if none exists and upload built artifacts with 1‑day retention

## Testing
- `go test -tags test`


------
https://chatgpt.com/codex/tasks/task_e_685e75590c60832f869b2c1a144a0a30