### PR TITLE
Fix go vet by excluding ebiten package on test builds

### DIFF
--- a/drawings/ebiten/graphics.go
+++ b/drawings/ebiten/graphics.go
@@ -1,3 +1,5 @@
+//go:build !test
+
 package ebdraw
 
 import (


### PR DESCRIPTION
## Summary
- avoid building ebiten drawing helpers when the `test` tag is set

## Testing
- `go vet -tags test ./...`
- `go test -tags test`


------
https://chatgpt.com/codex/tasks/task_e_685e82e2adbc832facc0e7d5b76e9ff3