### PR TITLE
Fix stub joystick struct for non-Linux builds

### DIFF
--- a/cmd/gorillia-tcell/joystick_stub.go
+++ b/cmd/gorillia-tcell/joystick_stub.go
@@ -2,7 +2,10 @@
 
 package main
 
-type joystick struct{}
+type joystick struct {
+    axis [2]int16
+    btn  [16]bool
+}
 
 func openJoystick() (*joystick, error) { return nil, nil }
 func (j *joystick) poll()              {}


### PR DESCRIPTION
## Summary
- define `axis` and `btn` fields in `joystick_stub.go` so builds on macOS/windows compile

## Testing
- `go test -tags test`

------
https://chatgpt.com/codex/tasks/task_e_685e85115658832fa7d836b9393099c5