### PR TITLE
Fix release workflow step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           path: dist


### PR DESCRIPTION
## Summary
- fix release workflow issue `gh release` failing due to missing `.git`

## Testing
- `go test -tags test`


------
https://chatgpt.com/codex/tasks/task_e_685f2f215ff0832fb8bfd8d7aa09094f