### PR TITLE
Package zipped artifacts in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,23 @@ jobs:
           args: build --clean --single-target
         env:
           CGO_ENABLED: '1'
+      - name: Set build vars
+        run: |
+          echo "GOOS=$(go env GOOS)" >> "$GITHUB_ENV"
+          echo "GOARCH=$(go env GOARCH)" >> "$GITHUB_ENV"
+      - name: Package artifacts
+        run: |
+          for dir in dist/*/; do
+            base="$(basename "${dir%/}")"
+            zip_name="${base}-${GOOS}-${GOARCH}.zip"
+            (cd "$dir" && zip -r "../$zip_name" .)
+          done
+          find dist -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} +
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ matrix.os }}
-          path: dist/*
+          name: dist-${{ env.GOOS }}-${{ env.GOARCH }}
+          path: dist/*.zip
           retention-days: 1
 
   release:
@@ -60,6 +72,6 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           files: |
-            dist/**
+            dist/**/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- zip each dist directory after running Goreleaser
- include GOOS and GOARCH in the zip filename
- only upload the zipped files as artifacts and release assets

## Testing
- `go test -tags test`


------
https://chatgpt.com/codex/tasks/task_e_685f32d17008832fa771399b39102ed6