### PR TITLE
ci: update nightly jobs to run 6am AEST on the 2nd of each month

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ on:
         type: boolean
   schedule:
     - cron: '17 3 1 * *'
-    - cron: '41 2 * * *'
+    - cron: '0 20 1 * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
@@ -111,7 +111,7 @@ jobs:
               if [[ "${{ github.event.schedule }}" == "17 3 1 * *" ]]; then
                 is_monthly=true
               fi
-              if [[ "${{ github.event.schedule }}" == "41 2 * * *" ]]; then
+              if [[ "${{ github.event.schedule }}" == "0 20 1 * *" ]]; then
                 is_nightly=true
               fi
               ;;


### PR DESCRIPTION
Updated the GitHub Actions workflow `ci.yml` so that the "nightly" jobs run specifically on the 2nd of each month at 6:00 AM AEST (Australian Eastern Standard Time). Since GitHub Actions schedules rely on UTC, the corresponding cron expression used is `0 20 1 * *`, which translates to 8:00 PM UTC on the 1st of the month. Both the `schedule` trigger and the condition that sets the `is_nightly` flag for the scheduled run were updated to match the new expression.

---
*PR created automatically by Jules for task [777618536466979421](https://jules.google.com/task/777618536466979421) started by @arran4*